### PR TITLE
Timeout long running actions, so user doesn't get stuck with spinner

### DIFF
--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -93,13 +93,13 @@ loadingIndicator Loading =
 
 -- | Allows to run the asynchronous action while showing the loading indicator
 --   and handling the result.
-runAffLoading
+runAffWithSpinner
   :: forall a.
      SetState
   -> (Either Error a -> Effect Unit) -- ^ result handler
   -> Aff a -- ^ asynchronous action
   -> Effect Unit
-runAffLoading setState handler action = do
+runAffWithSpinner setState handler action = do
    let timeoutSeconds = 30.0
    Aff.launchAff_ do
      loadingFiber <- Aff.forkAff do
@@ -135,7 +135,7 @@ navbarView { state, setState } =
       { paper: state.paper
       , loggedInUser: state.loggedInUser
       , logout: do
-          runAffLoading setState
+          runAffWithSpinner setState
             (case _ of
                Left err -> Log.error $ "Error during logout: " <> Error.message err
                Right _ ->  Log.info "Logout successful")
@@ -308,7 +308,7 @@ loginView { state, setState } = React.fragment
               Right user -> do
                 log "Fetching user succeeded"
                 setState \s -> s { loggedInUser = Just user }
-          , launchAff_: runAffLoading setState $ case _ of
+          , launchAff_: runAffWithSpinner setState $ case _ of
               Left err -> do
                 Log.error $ "Error during login: " <> Error.message err
               Right r -> pure unit

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -135,8 +135,9 @@ navbarView { state, setState } =
       { paper: state.paper
       , loggedInUser: state.loggedInUser
       , logout: do
-          Aff.launchAff_ $ withSpinner (setState <<< setLoading)
-            (Login.logout (setState <<< setLoggedInUser))
+          Aff.launchAff_ $ withSpinner (setState <<< setLoading) do
+            Login.logout
+            liftEffect $ setState $ setLoggedInUser Nothing
       }
 
 footerView :: React.JSX

--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -337,10 +337,10 @@ finalizeLogin props loginResponse = do
       pure unit
   liftEffect $ props.onUserFetch userResponse
 
--- | This is for wrapping whatever action is supposed to happen when the user logs out.
--- | It is then supposed to be passed to the component where the logging out is actually triggered.
-logout :: (Maybe Persona.User -> Effect Unit) -> Aff Unit
-logout setParentUser = do
+-- | Logout the user. Calls social-media SDKs and SSO library.
+--   Wipes out local storage.
+logout :: Aff Unit
+logout = do
   -- Facebook logout is invoked first, as it includes an HTTP request to the Facebook backend.
   -- Before the request has finished, it is not wanted to remove the current user data from local storage or the state of the caller component.
   -- This prevents flickering of the landing page right before the loading indicator is shown.
@@ -349,7 +349,6 @@ logout setParentUser = do
     logoutJanrain
     logoutGoogle
     deleteToken
-    setParentUser Nothing
 
 logoutFacebook :: Aff Unit
 logoutFacebook = do


### PR DESCRIPTION
This does the timeouting and prevents the spinner for staying indefinitely, but doesn't show anything to the user. Doing that will be a part of #7

Fixes #6   