### PR TITLE
Make JanrainSSO.endSession async (so that it waits for completion)

### DIFF
--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -345,8 +345,8 @@ logout setParentUser = do
   -- Before the request has finished, it is not wanted to remove the current user data from local storage or the state of the caller component.
   -- This prevents flickering of the landing page right before the loading indicator is shown.
   logoutFacebook
+  logoutJanrain
   liftEffect do
-    logoutJanrain
     logoutGoogle
     deleteToken
     setParentUser Nothing
@@ -365,10 +365,10 @@ logoutGoogle = do
   when isSignedWithGoogle do
     Google.signOut (Log.info "Logged out from Google.")
 
-logoutJanrain :: Effect Unit
+logoutJanrain :: Aff Unit
 logoutJanrain = do
-  JanrainSSO.endSession $ Just $ do
-    Console.log "Ended janrain sso session"
+  JanrainSSO.endSession
+  Console.log "Ended Janrain session"
 
 saveToken :: forall m. MonadEffect m => Persona.LoginResponse -> m Unit
 saveToken { token, ssoCode, uuid } = liftEffect do


### PR DESCRIPTION
the `end_session` method of SDK takes a callback that will be called upon the completion and does stuff asynchronously. So far we've been calling it with a no-op callback and proceeding with the normal flow.

Under slow network this created a gnarly race condition. The `end_session` would start executing (but veeeery slowly), while the app proceeds and switches back to the login screen. This causes the `check_session` to be triggered again, which picks up the still alive SSO session (`end_session` is still blocked on network) and log the user back in. BUM.

Here, I wrap the `end_session` in an aff, which allows us to conveniently "block" on it, and proceed with logout flow only after the SSO logout has been carried.