### PR TITLE
Make Google.logOut return an Aff

### DIFF
--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -345,9 +345,9 @@ logout setParentUser = do
   -- Before the request has finished, it is not wanted to remove the current user data from local storage or the state of the caller component.
   -- This prevents flickering of the landing page right before the loading indicator is shown.
   logoutFacebook
+  logoutGoogle
   liftEffect do
     logoutJanrain
-    logoutGoogle
     deleteToken
     setParentUser Nothing
 
@@ -359,11 +359,12 @@ logoutFacebook = do
     _ <- FB.logout sdk
     Log.info "Logged out from Facebook."
 
-logoutGoogle :: Effect Unit
+logoutGoogle :: Aff Unit
 logoutGoogle = do
-  isSignedWithGoogle <- Google.isSignedIn
+  isSignedWithGoogle <- liftEffect Google.isSignedIn
   when isSignedWithGoogle do
-    Google.signOut (Log.info "Logged out from Google.")
+    Google.signOut
+    Log.info "Logged out from Google."
 
 logoutJanrain :: Effect Unit
 logoutJanrain = do

--- a/packages/ksf-login/src/KSF/Login/Google/Google.js
+++ b/packages/ksf-login/src/KSF/Login/Google/Google.js
@@ -36,7 +36,7 @@ exports.isSignedIn_ = function() {
   return false;
 };
 
-exports.signOut_ = function(onSignOut) {
+exports.signOut_ = function() {
   var auth2 = gapi.auth2.getAuthInstance();
-  auth2.signOut().then(onSignOut);
+  return auth2.signOut();
 }

--- a/packages/ksf-login/src/KSF/Login/Google/Google.purs
+++ b/packages/ksf-login/src/KSF/Login/Google/Google.purs
@@ -1,7 +1,11 @@
 module KSF.Login.Google where
 
+import Control.Promise (Promise)
+import Control.Promise as Promise
 import Data.Unit (Unit)
 import Effect (Effect)
+import Effect.Aff (Aff)
+import Effect.Aff as Aff
 import Effect.Uncurried (EffectFn1, mkEffectFn1, runEffectFn1)
 import Web.DOM as DOM
 
@@ -26,7 +30,7 @@ foreign import attachClickHandler_
        , onFailure :: EffectFn1 Error Unit
        }
        Unit
-foreign import signOut_ :: EffectFn1 (Effect Unit) Unit
+foreign import signOut_ :: Effect (Promise Unit)
 foreign import isSignedIn_ :: Effect Boolean
 
 attachClickHandler
@@ -43,5 +47,5 @@ attachClickHandler { node, options, onSuccess, onFailure } =
 isSignedIn :: Effect Boolean
 isSignedIn = isSignedIn_
 
-signOut :: Effect Unit -> Effect Unit
-signOut = runEffectFn1 signOut_
+signOut :: Aff Unit
+signOut = Promise.toAffE signOut_

--- a/psc-package.json
+++ b/psc-package.json
@@ -4,6 +4,7 @@
   "source": "https://github.com/KSF-Media/package-sets.git",
   "depends": [
     "aff",
+    "aff-promise",
     "formatters",
     "datetime",
     "react-basic",


### PR DESCRIPTION
This is to fix the same bug as in #17

I would have loved to handle the rest of Google SDK in the same way, but probably later, along with stopping using `attachClickHandler`.