### PR TITLE
Enable SSO debug logs

### DIFF
--- a/packages/ksf-login/src/JanrainSSO.js
+++ b/packages/ksf-login/src/JanrainSSO.js
@@ -1,6 +1,7 @@
 exports.sso = JANRAIN.SSO;
 
 exports.loadConfig = function() {
+  window.localStorage && window.localStorage.setItem('janrainSsoDebugEnabled', true);
   var baseUrl = window.location.protocol + "//" + window.location.host;
   var config = {
     client_id: process.env.JANRAIN_LOGIN_CLIENT_ID,


### PR DESCRIPTION
I've read Janrain's sso source and figured out that there is a way to
enable debugging output. Weirdly enough it seems to fix #22 for
me (both in Firefox and Chrome).

I'm not really trusting such fix, but I thought that it's a good
idea to commit it and try on staging. It won't hurt to have debug
logs either way.