### PR TITLE
Only do JanrainSSO.end_session() when SSO have actually worked

### DIFF
--- a/packages/ksf-login/src/JanrainSSO.purs
+++ b/packages/ksf-login/src/JanrainSSO.purs
@@ -3,7 +3,7 @@ module JanrainSSO where
 import Prelude
 
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), isJust)
 import Data.Nullable (Nullable)
 import Data.Nullable as Nullable
 import Effect (Effect)
@@ -12,8 +12,15 @@ import Effect.Aff as Aff
 import Effect.Class.Console as Console
 import Effect.Exception as Exception
 import Effect.Uncurried (EffectFn1, runEffectFn1)
+import LocalStorage as LocalStorage
 
 foreign import loadConfig :: Effect Config
+
+setSsoSuccess :: Effect Unit
+setSsoSuccess = LocalStorage.setItem "KSF_JANRAIN_SSO_SUCCESS" "true"
+
+getSsoSuccess :: Effect Boolean
+getSsoSuccess = isJust <$> LocalStorage.getItem "KSF_JANRAIN_SSO_SUCCESS"
 
 foreign import sso ::
   { check_session

--- a/packages/ksf-login/src/JanrainSSO.purs
+++ b/packages/ksf-login/src/JanrainSSO.purs
@@ -35,7 +35,7 @@ endSession :: Aff Unit
 endSession = Aff.makeAff \callback -> do
   Exception.catchException
     (\err -> do
-      Console.error $ "JanrainSSO.set_session failed: " <> Exception.message err
+      Console.error $ "JanrainSSO.end_session failed: " <> Exception.message err
       callback $ Left err)
     (runEffectFn1 sso.end_session $ Nullable.toNullable $ Just $ callback $ Right unit)
   pure Aff.nonCanceler

--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -6,7 +6,6 @@ import Control.Monad.Error.Class (catchError, throwError, try)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Control.Parallel (parSequence_)
 import Data.Either (Either(..), either)
-import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..), fromMaybe, isJust, isNothing, maybe)
 import Data.Nullable (Nullable, toNullable)
 import Data.Nullable as Nullable
@@ -389,4 +388,4 @@ loadToken = runMaybeT do
   pure { token, ssoCode: Nullable.toNullable Nothing, uuid }
 
 deleteToken :: Effect Unit
-deleteToken = traverse_ LocalStorage.removeItem [ "token", "uuid" ]
+deleteToken = LocalStorage.clear

--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -128,10 +128,12 @@ receiveProps { props, state, setState, isFirstMount } = when isFirstMount do
              { callback_failure: mkEffectFn1 \a -> do
                 Console.log "Janrain SSO failure"
              , callback_success: mkEffectFn1 \a -> do
+                JanrainSSO.setSsoSuccess
                 Console.log "Janrain SSO success"
              , capture_error: mkEffectFn1 \a -> do
                 Console.log "Janrain SSO capture error"
              , capture_success: mkEffectFn1 \r@({ result: { accessToken, userData: { uuid } } }) -> do
+                JanrainSSO.setSsoSuccess
                 Console.log "Janrain SSO capture success"
                 Console.log $ unsafeCoerce r
                 props.launchAff_ do
@@ -352,7 +354,9 @@ logout = do
   parSequence_
     [ logoutFacebook `catchError` Console.errorShow
     , logoutGoogle   `catchError` Console.errorShow
-    , logoutJanrain  `catchError` Console.errorShow
+    , do needsSsoLogout <- liftEffect JanrainSSO.getSsoSuccess
+         when needsSsoLogout do
+           logoutJanrain  `catchError` Console.errorShow
     ]
 
 logoutFacebook :: Aff Unit

--- a/packages/ksf-login/src/LocalStorage.js
+++ b/packages/ksf-login/src/LocalStorage.js
@@ -11,6 +11,7 @@ JavaScript, not even once.
 
 exports.setItem_ = function(k, v) {
   window.localStorage.setItem(k, v);
+  return {};
 };
 
 exports.getItem_ = function(k) {
@@ -19,4 +20,5 @@ exports.getItem_ = function(k) {
 
 exports.removeItem_ = function(k) {
   window.localStorage.removeItem(k);
+  return {};
 }

--- a/packages/ksf-login/src/LocalStorage.js
+++ b/packages/ksf-login/src/LocalStorage.js
@@ -22,3 +22,8 @@ exports.removeItem_ = function(k) {
   window.localStorage.removeItem(k);
   return {};
 }
+
+exports.clear = function() {
+  window.localStorage.clear();
+  return {};
+}

--- a/packages/ksf-login/src/LocalStorage.purs
+++ b/packages/ksf-login/src/LocalStorage.purs
@@ -10,6 +10,7 @@ import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
 foreign import setItem_ :: EffectFn2 String String Unit
 foreign import getItem_ :: EffectFn1 String (Nullable String)
 foreign import removeItem_ :: EffectFn1 String Unit
+foreign import clear :: Effect Unit
 
 setItem :: String -> String -> Effect Unit
 setItem = runEffectFn2 setItem_


### PR DESCRIPTION
A fix for #22 which amounts to following:

- When SSO succeeds to capture (`capture_success`) and/or update session (`callback_success`) we set `localStorage.KSF_JANRAIN_SSO_SUCCESS`
- We don't call `end_session` unless `KSF_JANRAIN_SSO_SUCCESS` is set (as there is no need)