### PR TITLE
Don't throw an error when the <Button> node is not found

### DIFF
--- a/packages/ksf-button/src/KSF/Button/Component.purs
+++ b/packages/ksf-button/src/KSF/Button/Component.purs
@@ -2,10 +2,11 @@ module KSF.Button.Component where
 
 import Prelude
 
-import Data.Either (either)
+import Data.Either (Either(..))
 import Data.Maybe (Maybe)
 import Effect (Effect)
-import Effect.Exception as Exception
+import Effect.Class.Console as Console
+import Effect.Exception as Error
 import KSF.Button.View as View
 import React.Basic (JSX)
 import React.Basic as React
@@ -23,8 +24,12 @@ component :: React.Component Props
 component = React.component { displayName: "Button", render, initialState: {}, receiveProps }
   where
     receiveProps { instance_, props, isFirstMount } = when isFirstMount do
-      node <- DOM.findDOMNode instance_
-      either Exception.throwException props.onLoad node
+      mountedNode <- DOM.findDOMNode instance_
+      case mountedNode of
+        Left err -> do
+          Console.error $ "Button component: " <> Error.message err
+        Right node -> do
+          props.onLoad node
 
 render :: forall r. { props :: Props | r } -> JSX
 render { props } =


### PR DESCRIPTION
I don't yet know the exact reason for it, but I started getting the following error that prevents the application from loading at all:

![2018-11-09-144859_643x220_scrot](https://user-images.githubusercontent.com/2613966/48333945-cbc98d00-e661-11e8-9f33-8c413535f985.png)

It comes from the our button component that tries to find it's DOM node on the first mount and throws the exception if it's not found. To be on the safe side, I've replaced the throw with logging.

The only reason that we need the button's DOM node is because we are using [`attachClickHandler`](https://developers.google.com/identity/sign-in/web/reference#googleauthattachclickhandlercontainer-options--onsuccess-onfailure) method of Google SDK. It simply takes a pointer to a `div` element of a social-login button and does all the stuff when the user clicks it. We've copied this approach from existing social-login implementation in prenumerera.

It's also possible to handle the click ourselves using normal React click handlers and call corresponding methods of Google's SDK. It's documented [here](https://developers.google.com/identity/protocols/OAuth2UserAgent). But when implementing SoMe me and @vapaj decided against that since it seemed less error-prone to just give Google a button and have it do all the stuff (and it already worked well for prenumerera).