### PR TITLE
Catch and display global errors in mitt-konto

### DIFF
--- a/apps/mitt-konto/resources/mitt-konto.less
+++ b/apps/mitt-konto/resources/mitt-konto.less
@@ -201,6 +201,15 @@ h2.mitt-konto---heading {
     }
 }
 
+.mitt-konto--error-message {
+    padding: 0.8em;
+    font-weight: 300;
+    font-size: 1.3em;
+    border-radius: 0 0 0.5em 0.5em;
+    color: @grey-deepdark;
+    background-color: salmon;
+}
+
 .mitt-konto--profile {
     padding-right: 2em;
     @media @to-medium {

--- a/apps/mitt-konto/resources/mitt-konto.less
+++ b/apps/mitt-konto/resources/mitt-konto.less
@@ -201,15 +201,6 @@ h2.mitt-konto---heading {
     }
 }
 
-.mitt-konto--error-message {
-    padding: 0.8em;
-    font-weight: 300;
-    font-size: 1.3em;
-    border-radius: 0 0 0.5em 0.5em;
-    color: @grey-deepdark;
-    background-color: salmon;
-}
-
 .mitt-konto--profile {
     padding-right: 2em;
     @media @to-medium {

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -4,11 +4,10 @@ import Prelude
 
 import Data.Array ((:))
 import Data.Either (Either(..), either)
-import Data.Foldable (foldMap, oneOf, traverse_)
+import Data.Foldable (foldMap, oneOf)
 import Data.JSDate (JSDate, parse)
 import Data.Maybe (Maybe(..))
 import Data.String (toUpper)
-import Data.Traversable (traverse)
 import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Aff as Aff
@@ -76,8 +75,9 @@ app = React.component
     render { state, setState } =
       React.fragment
         [ navbarView { state, setState }
-        , alertView state.alert
-        , classy DOM.div "clearfix"
+        , classy DOM.div "mt4 mb4"
+            [ foldMap alertView state.alert ]
+        , classy DOM.div "mt4 mb4 clearfix"
             [ classy DOM.div "mitt-konto--main-container col-10 lg-col-7 mx-auto"
                 [ mittKonto ]
             ]
@@ -85,7 +85,7 @@ app = React.component
         ]
      where
        mittKonto =
-         classy DOM.div "mitt-konto--container clearfix mt4"
+         classy DOM.div "mitt-konto--container clearfix"
            [ foldMap loadingIndicator state.loading
            , case state.loggedInUser of
                Just user -> userView { user }
@@ -149,12 +149,10 @@ navbarView { state, setState } =
             liftEffect $ setState $ setLoggedInUser Nothing
       }
 
-alertView :: Maybe Alert -> JSX
-alertView = foldMap \alert ->
-  classy DOM.div "clearfix"
-    [ classy DOM.div "col-4 mx-auto center"
-      [ React.element Alert.component alert ]
-    ]
+alertView :: Alert -> JSX
+alertView alert =
+  classy DOM.div "col-4 mx-auto center"
+    [ React.element Alert.component alert ]
 
 footerView :: React.JSX
 footerView =

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -321,7 +321,7 @@ loginView { state, setState } = React.fragment
                 log "Fetching user succeeded"
                 setState $ setLoggedInUser $ Just user
           , launchAff_:
-              Aff.runAff_ (either (setState <<< setAlert <<< errorAlert) pure)
+              Aff.runAff_ (setState <<< setAlert <<< either errorAlert (const Nothing))
                 <<< withSpinner (setState <<< setLoading)
           }
 

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -323,7 +323,7 @@ loginView { state, setState } = React.fragment
           , launchAff_: Aff.runAff_
               (case _ of
                  Left err
-                   | Just errMessage <- Persona.networkError err -> do
+                   | Just { method, url } <- Persona.networkError err -> do
                        setState $ setErrorMessage $ Just
                          "Failed to connect. Check your connection and try again later."
                    | otherwise -> do

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -37,6 +37,7 @@ type State =
   , loggedInUser :: Maybe Persona.User
   , loading :: Maybe Loading
   , showWelcome :: Boolean
+  , errorMessage :: Maybe String
   }
 
 setLoading :: Maybe Loading -> State -> State
@@ -44,6 +45,9 @@ setLoading loading = _ { loading = loading }
 
 setLoggedInUser :: Maybe Persona.User -> State -> State
 setLoggedInUser loggedInUser = _ { loggedInUser = loggedInUser }
+
+setErrorMessage :: Maybe String -> State -> State
+setErrorMessage errorMessage = _ { errorMessage = errorMessage }
 
 data Loading = Loading
 
@@ -57,6 +61,7 @@ app = React.component
       , loggedInUser: Nothing
       , loading: Nothing
       , showWelcome: true
+      , errorMessage: Nothing
       }
   , receiveProps
   , render
@@ -68,6 +73,7 @@ app = React.component
     render { state, setState } =
       React.fragment
         [ navbarView { state, setState }
+        , errorMessageView state.errorMessage
         , classy DOM.div "clearfix"
             [ classy DOM.div "mitt-konto--main-container col-10 lg-col-7 mx-auto"
                 [ mittKonto ]
@@ -139,6 +145,13 @@ navbarView { state, setState } =
             Login.logout
             liftEffect $ setState $ setLoggedInUser Nothing
       }
+
+errorMessageView :: Maybe String -> JSX
+errorMessageView = foldMap \errorMessage ->
+  classy DOM.div "clearfix"
+    [ classy DOM.div "col-4 mx-auto center mitt-konto--error-message"
+      [ DOM.text errorMessage ]
+    ]
 
 footerView :: React.JSX
 footerView =

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -352,13 +352,13 @@ errorAlert err = oneOf
   [ do { method, url } <- Persona.networkError err
        pure
          { level: Alert.danger
-         , title: "Failed to connect."
-         , message: "Check your connection and try again later."
+         , title: "Anslutningen misslyckades."
+         , message: "Vänligen kontrollera din internetanslutning och försök om en stund igen."
          }
   , pure
       { level: Alert.warning
-      , title: "Unknown failure"
-      , message: "Something went wrong"
+      , title: "Något gick fel vid inloggningen."
+      , message: "Vänligen försök om en stund igen."
       }
   ]
 

--- a/build-purs.rb
+++ b/build-purs.rb
@@ -11,6 +11,7 @@ purs_modules = [
   PursModule.new('KSF.Navbar.Component', 'packages/ksf-navbar'),
   PursModule.new('KSF.DescriptionList.Component', 'packages/ksf-description-list'),
   PursModule.new('KSF.Subscription.Component', 'packages/ksf-subscription'),
+  PursModule.new('KSF.Alert.Component', 'packages/ksf-alert'),
   PursModule.new('MittKonto.Main', 'apps/mitt-konto'),
 ]
 

--- a/less/Alert.less
+++ b/less/Alert.less
@@ -1,0 +1,1 @@
+../packages/ksf-alert/src/KSF/Alert/Alert.less

--- a/less/ksf-colors.less
+++ b/less/ksf-colors.less
@@ -49,3 +49,10 @@
 
 @nude: #eceae6;
 @white: white;
+
+/* Alert colors */
+
+@alert-success: #268729;
+@alert-info: #00698e;
+@alert-warning: #ffd429;
+@alert-danger: #e6492e;

--- a/packages/ksf-alert/package.json
+++ b/packages/ksf-alert/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@affresco/ksf-alert",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2"
+  }
+}

--- a/packages/ksf-alert/src/KSF/Alert/Alert.less
+++ b/packages/ksf-alert/src/KSF/Alert/Alert.less
@@ -1,0 +1,34 @@
+@import (reference) 'ksf-colors';
+
+.alert {
+  width: 100%;
+  max-width: 300px;
+  min-width: 100px;
+
+  padding: 20px;
+  margin: 10px auto;
+
+  text-align: left;
+  font-size: 16px;
+
+  background-color: white;
+  box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.15);
+
+  border-bottom-style: solid;
+  border-bottom-width: 10px;
+
+  &.alert--success { border-bottom-color: @alert-success; }
+  &.alert--info    { border-bottom-color: @alert-info;    }
+  &.alert--warning { border-bottom-color: @alert-warning; }
+  &.alert--danger  { border-bottom-color: @alert-danger;  }
+
+  .alert__title {
+    font-weight: 400;
+    font-size: 1.25em;
+    line-height: 2em;
+  }
+
+  .alert__message {
+    font-weight: 300;
+  }
+}

--- a/packages/ksf-alert/src/KSF/Alert/Component.js
+++ b/packages/ksf-alert/src/KSF/Alert/Component.js
@@ -1,0 +1,1 @@
+exports.alertStyles = require('./less/Alert.less');

--- a/packages/ksf-alert/src/KSF/Alert/Component.purs
+++ b/packages/ksf-alert/src/KSF/Alert/Component.purs
@@ -1,2 +1,57 @@
 module KSF.Alert.Component where
 
+import Prelude
+import React.Basic.DOM as JSX
+import React.Basic.Extended (JSX, Style)
+import React.Basic.Extended as React
+
+foreign import alertStyles :: Style
+
+newtype Level = Level String
+
+danger :: Level
+danger = Level "danger"
+
+warning :: Level
+warning = Level "warning"
+
+info :: Level
+info = Level "info"
+
+success :: Level
+success = Level "success"
+
+type Alert =
+  { level   :: Level
+  , title   :: String
+  , message :: String
+  }
+
+type Props = Alert
+
+jsComponent :: React.Component Props
+jsComponent = component
+
+component :: React.Component Props
+component = React.stateless
+  { displayName: "Alert"
+  , render: React.requireStyle alertStyles <<< render
+  }
+
+render :: Props -> JSX
+render alert =
+  JSX.div
+    { className: "alert" <> " " <> alertLevelClass alert.level
+    , children:
+        [ JSX.div
+            { className: "alert__title"
+            , children: [ JSX.text alert.title ]
+            }
+        , JSX.div
+            { className: "alert__message"
+            , children: [ JSX.text alert.message ]
+            }
+        ]
+    }
+  where
+    alertLevelClass (Level level) = "alert--" <> level

--- a/packages/ksf-alert/src/KSF/Alert/Component.purs
+++ b/packages/ksf-alert/src/KSF/Alert/Component.purs
@@ -1,0 +1,2 @@
+module KSF.Alert.Component where
+

--- a/packages/persona/src/Persona.js
+++ b/packages/persona/src/Persona.js
@@ -3,6 +3,12 @@ var Persona = require('persona');
 
 Persona.ApiClient.instance.basePath = process.env.PERSONA_URL;
 
+// https://visionmedia.github.io/superagent/#timeouts
+Persona.ApiClient.instance.timeout = {
+  response: 5000, // the server only has 5 seconds to respond
+  deadline: 20000 // but up to 20 seconds of overall data transfer
+};
+
 exports.loginApi = new Persona.LoginApi(Persona.ApiClient.instance);
 exports.usersApi = new Persona.UsersApi(Persona.ApiClient.instance);
 

--- a/packages/persona/src/Persona.js
+++ b/packages/persona/src/Persona.js
@@ -20,8 +20,13 @@ exports.callApi_ = function(api, methodName, body, opts) {
         // If we have an error message we decode it and attach it as the `data`
         // so we can eventually read the error from there
         if (res && res.text) {
-          err.data = JSON.parse(res.text);
+          try {
+            err.data = JSON.parse(res.text);
+          } catch (decodeErr) {
+            console.error("Failed to parse persona's response body", decodeErr)
+          }
         }
+        console.error("Superagent error", err);
         onError(err);
       } else {
         onSuccess(data);

--- a/packages/persona/src/Persona.purs
+++ b/packages/persona/src/Persona.purs
@@ -9,15 +9,14 @@ import Data.Function.Uncurried (Fn4, runFn4)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.JSDate (JSDate)
-import Data.Maybe (Maybe, isJust)
+import Data.Maybe (Maybe, isNothing)
 import Data.Nullable (Nullable)
 import Data.String (toLower)
 import Data.Traversable (traverse)
 import Effect.Aff (Aff)
 import Effect.Aff.Compat (EffectFnAff, fromEffectFnAff)
 import Effect.Exception (Error)
-import Foreign (readNullOrUndefined)
-import Effect.Exception as Error
+import Foreign (Foreign)
 import Foreign (readNullOrUndefined, unsafeToForeign) as Foreign
 import Foreign.Generic.EnumEncoding (genericDecodeEnum, genericEncodeEnum)
 import Foreign.Index (readProp) as Foreign
@@ -134,29 +133,20 @@ internalServerError err = do
   guard $ status >= 500 && status <= 599
   pure { status }
 
+-- | Matches network error produced by superagent.
+--   Checks that it has `method` and `url` fields, but no `status`.
+networkError :: Error -> Maybe { method :: String, url :: String }
+networkError err = do
+  method <- errorField "method" err
+  url <- errorField "url" err
+  guard $ isNothing $ errorField "status" err :: Maybe Foreign
+  pure { method, url }
+
 -- | Check if an error has some field and it's not null or undefined.
 errorField :: forall a. ReadForeign a => String -> Error -> Maybe a
 errorField field =
   join <<< hush
     <<< (traverse JSON.read =<< _)
-    <<< runExcept
-    <<< do readNullOrUndefined <=< Foreign.readProp field
-    <<< Foreign.unsafeToForeign
-
--- | Matches network error produced by superagent.
---   Checks that it has `method` and `url` fields, but no `status`.
-networkError :: Error -> Maybe String
-networkError err = do
-  guard $ hasField "method" err
-  guard $ hasField "url" err
-  guard $ not $ hasField "status" err
-  pure $ Error.message err
-
--- | Check if an error has some field and it's not null or undefined.
-hasField :: String -> Error -> Boolean
-hasField field =
-  isJust
-    <<< join <<< hush
     <<< runExcept
     <<< do Foreign.readNullOrUndefined <=< Foreign.readProp field
     <<< Foreign.unsafeToForeign


### PR DESCRIPTION

![2018-11-13-101155_884x419_scrot](https://user-images.githubusercontent.com/2613966/48399844-765ab200-e72d-11e8-856f-33826e7015db.png)

- [X] timeout requests appropriately
- [X] have a view area to show the error messages
- [X] capture network errors
- [ ] capture 5XX responses
- [ ] translate messages to Swedish