### PR TITLE
Call Janrain checkSession before logging out

### DIFF
--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -373,6 +373,9 @@ logoutGoogle = do
 
 logoutJanrain :: Aff Unit
 logoutJanrain = do
+  -- If JanrainSSO.checkSession is not called before this function,
+  -- the JanrainSSO.endSession will hang.
+  -- So call JanrainSSO.checkSession first just to be safe.
   config <- liftEffect $ JanrainSSO.loadConfig
   liftEffect $ JanrainSSO.checkSession config
   JanrainSSO.endSession

--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -373,6 +373,8 @@ logoutGoogle = do
 
 logoutJanrain :: Aff Unit
 logoutJanrain = do
+  config <- liftEffect $ JanrainSSO.loadConfig
+  liftEffect $ JanrainSSO.checkSession config
   JanrainSSO.endSession
   Console.log "Ended Janrain session"
 


### PR DESCRIPTION
This prevents Janrain SSO logout from hanging.