### PR TITLE
Login internal server error handling

### DIFF
--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -139,7 +139,16 @@ receiveProps { props, state, setState, isFirstMount } = when isFirstMount do
                 Console.log "Janrain SSO capture success"
                 Console.log $ unsafeCoerce r
                 props.launchAff_ do
-                  loginResponse <- Persona.loginSso { accessToken, uuid }
+                  loginResponse <-
+                    Persona.loginSso { accessToken, uuid } `catchError` case _ of
+                      err | Just serverError <- Persona.internalServerError err -> do
+                              Console.error "Something went wrong with SSO login"
+                              liftEffect $ setState \s -> s
+                                { errors { login = Just Login.SomethingWentWrong } }
+                              throwError err
+                          | otherwise -> do
+                              Console.error "An unexpected error occurred during SSO login"
+                              throwError err
                   finalizeLogin props loginResponse
             }
 
@@ -209,7 +218,9 @@ render { props, state, setState } =
                      { errors { login = Just Login.InvalidCredentials } }
                    throwError err
                | Just serverError <- Persona.internalServerError err -> do
-                   Console.log "internal server error"
+                   Console.error "Something went wrong with traditional login"
+                   liftEffect $ setState \s -> s
+                     { errors { login = Just Login.SomethingWentWrong } }
                    throwError err
                | otherwise -> do
                    Console.error "An unexpected error occurred during traditional login"
@@ -325,6 +336,11 @@ render { props, state, setState } =
                           }
                         }
                     throwError err
+                | Just serverError <- Persona.internalServerError err -> do
+                    Console.error "Something went wrong with SoMe login"
+                    liftEffect $ setState \s -> s
+                      { errors { login = Just Login.SomethingWentWrong } }
+                    throwError err
                 | otherwise -> do
                      Console.error "An unexpected error occurred during SoMe login"
                      throwError err
@@ -338,12 +354,14 @@ finalizeLogin props loginResponse = do
   userResponse <- try do
     Persona.getUser loginResponse.uuid loginResponse.token
   case userResponse of
-    -- If fetching fails, token is probably old -> clear local storage
-    -- TODO: Actually check the response body
-    Left err  -> do
-      Console.error "Failed to fetch the user: deleting the token"
-      liftEffect deleteToken
-      throwError err
+    Left err
+      | Just (errData :: Persona.TokenInvalid) <- Persona.errorData err -> do
+          Console.error "Failed to fetch the user: Invalid token"
+          liftEffect deleteToken
+          throwError err
+      | otherwise -> do
+          Console.error "Failed to fetch the user"
+          throwError err
     Right user -> do
       Console.info "User fetched successfully"
       pure unit

--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -208,6 +208,9 @@ render { props, state, setState } =
                    liftEffect $ setState \s -> s
                      { errors { login = Just Login.InvalidCredentials } }
                    throwError err
+               | Just serverError <- Persona.internalServerError err -> do
+                   Console.log "internal server error"
+                   throwError err
                | otherwise -> do
                    Console.error "An unexpected error occurred during traditional login"
                    throwError err

--- a/packages/ksf-login/src/KSF/Login/Component.purs
+++ b/packages/ksf-login/src/KSF/Login/Component.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Monad.Error.Class (catchError, throwError, try)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Control.Parallel (parSequence_)
-import Data.Either (Either(..), either)
+import Data.Either (Either(..), either, isLeft)
 import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..), fromMaybe, isJust, isNothing, maybe)
 import Data.Nullable (Nullable, toNullable)
@@ -33,12 +33,12 @@ import React.Basic.Extended as React
 import Record as Record
 import Unsafe.Coerce (unsafeCoerce)
 
+
 type JSProps =
   { onMerge            :: Nullable (Effect Unit)
   , onMergeCancelled   :: Nullable (Effect Unit)
--- TODO:
---  , onLoginSuccess     :: Nullable (EffectFn1 Persona.LoginResponse Unit)
---  , onLoginFail        :: Nullable (EffectFn1 Error Unit)
+  , onLoginSuccess     :: Nullable (EffectFn1 Persona.LoginResponse Unit)
+  , onLoginFail        :: Nullable (EffectFn1 Error Unit)
   , onUserFetchFail    :: Nullable (EffectFn1 Error Unit)
   , onUserFetchSuccess :: Nullable (EffectFn1 Persona.User Unit)
   , onLoading          :: Nullable (Effect Unit)
@@ -49,6 +49,10 @@ fromJSProps :: JSProps -> Props
 fromJSProps jsProps =
   { onMerge: fromMaybe (pure unit) $ Nullable.toMaybe jsProps.onMerge
   , onMergeCancelled: fromMaybe (pure unit) $ Nullable.toMaybe jsProps.onMergeCancelled
+  , onLogin:
+      Just $ either
+        (maybe (const $ pure unit) runEffectFn1 $ Nullable.toMaybe jsProps.onLoginFail)
+        (maybe (const $ pure unit) runEffectFn1 $ Nullable.toMaybe jsProps.onLoginSuccess)
   , onUserFetch:
       either
         (maybe (const $ pure unit) runEffectFn1 $ Nullable.toMaybe jsProps.onUserFetchFail)
@@ -64,8 +68,7 @@ fromJSProps jsProps =
 type Props =
   { onMerge :: Effect Unit
   , onMergeCancelled :: Effect Unit
--- TODO:
---  , onLogin :: Either Error Persona.LoginResponse -> Effect Unit
+  , onLogin :: Maybe (Either Error Persona.LoginResponse -> Effect Unit)
   , onUserFetch :: Either Error Persona.User -> Effect Unit
   , launchAff_ :: Aff Unit -> Effect Unit
   }
@@ -206,28 +209,37 @@ render { props, state, setState } =
 
     onLogin :: Effect Unit
     onLogin = props.launchAff_ do
-      loginResponse <-
+      loginResponse <- try $
         Persona.login
           { username: state.formEmail
           , password: state.formPassword
           , mergeToken: toNullable $ map _.token state.merge
-          } `catchError` case _ of
-           err | Just (errData :: Persona.InvalidCredentials) <- Persona.errorData err -> do
-                   Console.error errData.invalid_credentials.description
-                   liftEffect $ setState \s -> s
-                     { errors { login = Just Login.InvalidCredentials } }
-                   throwError err
-               | Just serverError <- Persona.internalServerError err -> do
-                   Console.error "Something went wrong with traditional login"
-                   liftEffect $ setState \s -> s
-                     { errors { login = Just Login.SomethingWentWrong } }
-                   throwError err
-               | otherwise -> do
-                   Console.error "An unexpected error occurred during traditional login"
-                   throwError err
-      -- removing merge token from state in case of success
-      liftEffect $ setState \s -> s { merge = Nothing }
-      finalizeLogin props loginResponse
+          }
+      if isNothing props.onLogin
+        then case loginResponse of
+          Left err -> catchErr err
+          Right u -> do
+            -- removing merge token from state in case of success
+            liftEffect $ setState \s -> s { merge = Nothing }
+            finalizeLogin props u
+        else do
+          let onLoginCallback = fromMaybe (\_ -> pure unit) props.onLogin
+          liftEffect $ onLoginCallback loginResponse
+      where
+        catchErr err
+          | Just (errData :: Persona.InvalidCredentials) <- Persona.errorData err = do
+              Console.error errData.invalid_credentials.description
+              liftEffect $ setState \s -> s
+                { errors { login = Just Login.InvalidCredentials } }
+              throwError err
+          | Just serverError <- Persona.internalServerError err = do
+              Console.error "Something went wrong with traditional login"
+              liftEffect $ setState \s -> s
+                { errors { login = Just Login.SomethingWentWrong } }
+              throwError err
+          | otherwise = do
+              Console.error "An unexpected error occurred during traditional login"
+              throwError err
 
     onFacebookLogin :: Effect Unit
     onFacebookLogin = props.launchAff_ do

--- a/packages/ksf-login/src/KSF/Login/Login.purs
+++ b/packages/ksf-login/src/KSF/Login/Login.purs
@@ -5,3 +5,4 @@ data Error =
   | FacebookEmailMissing
   | EmailMismatchError
   | GoogleAuthInitError
+  | SomethingWentWrong

--- a/packages/ksf-login/src/KSF/Login/View.purs
+++ b/packages/ksf-login/src/KSF/Login/View.purs
@@ -313,3 +313,5 @@ formatErrorMessage err =
                 }
             , DOM.text "."
             ]
+        Login.SomethingWentWrong ->
+          DOM.text "Något gick fel vid inloggningen. Vänligen försök om en stund igen."


### PR DESCRIPTION
Catches internal server errors from Persona. Shows a simple error message to the user above the login form.

Fixes #14

~~TODO:~~
~~Add callback from parent~~