### PR TITLE
Check for FB object before loading Facebook SDK

### DIFF
--- a/packages/ksf-login/src/KSF/Login/Facebook/Sdk.js
+++ b/packages/ksf-login/src/KSF/Login/Facebook/Sdk.js
@@ -54,15 +54,17 @@ exports._init = function(callback) {
           window.isFBLoaded = true;
           callback(FB)(); // callback itself returns an effect
         };
-        (function(d, s, id){
-          var js, fjs = d.getElementsByTagName(s)[0];
-          if (d.getElementById(id)) {return;}
-          js = d.createElement(s);
-          js.id = id;
-          var debug = fbConfig['debug'] ? "/debug" : "";
-          js.src = "//connect.facebook.net/" + fbConfig['locale'] + "/sdk" + debug + ".js";
-          fjs.parentNode.insertBefore(js, fjs);
-        }(window.document, 'script', 'facebook-jssdk'));
+        if (typeof FB !== 'undefined') {
+          (function(d, s, id){
+            var js, fjs = d.getElementsByTagName(s)[0];
+            if (d.getElementById(id)) {return;}
+            js = d.createElement(s);
+            js.id = id;
+            var debug = fbConfig['debug'] ? "/debug" : "";
+            js.src = "//connect.facebook.net/" + fbConfig['locale'] + "/sdk" + debug + ".js";
+            fjs.parentNode.insertBefore(js, fjs);
+          }(window.document, 'script', 'facebook-jssdk'));
+        }
       };
     }
   }

--- a/packages/ksf-login/src/KSF/Login/Facebook/Sdk.js
+++ b/packages/ksf-login/src/KSF/Login/Facebook/Sdk.js
@@ -45,7 +45,7 @@ exports._api = function(fb, path, method, params, callback) {
 exports._init = function(callback) {
   return function(fbConfig) {
     return function() { // returns an effect
-      if (window.isFBLoaded) {
+      if (window.isFBLoaded || typeof FB === 'object') {
         callback(FB)();
       } else {
         window.fbAsyncInit = function() {
@@ -54,17 +54,15 @@ exports._init = function(callback) {
           window.isFBLoaded = true;
           callback(FB)(); // callback itself returns an effect
         };
-        if (typeof FB === 'undefined') {
-          (function(d, s, id){
-            var js, fjs = d.getElementsByTagName(s)[0];
-            if (d.getElementById(id)) {return;}
-            js = d.createElement(s);
-            js.id = id;
-            var debug = fbConfig['debug'] ? "/debug" : "";
-            js.src = "//connect.facebook.net/" + fbConfig['locale'] + "/sdk" + debug + ".js";
-            fjs.parentNode.insertBefore(js, fjs);
-          }(window.document, 'script', 'facebook-jssdk'));
-        }
+        (function(d, s, id){
+          var js, fjs = d.getElementsByTagName(s)[0];
+          if (d.getElementById(id)) {return;}
+          js = d.createElement(s);
+          js.id = id;
+          var debug = fbConfig['debug'] ? "/debug" : "";
+          js.src = "//connect.facebook.net/" + fbConfig['locale'] + "/sdk" + debug + ".js";
+          fjs.parentNode.insertBefore(js, fjs);
+        }(window.document, 'script', 'facebook-jssdk'));
       };
     }
   }

--- a/packages/ksf-login/src/KSF/Login/Facebook/Sdk.js
+++ b/packages/ksf-login/src/KSF/Login/Facebook/Sdk.js
@@ -54,7 +54,7 @@ exports._init = function(callback) {
           window.isFBLoaded = true;
           callback(FB)(); // callback itself returns an effect
         };
-        if (typeof FB !== 'undefined') {
+        if (typeof FB === 'undefined') {
           (function(d, s, id){
             var js, fjs = d.getElementsByTagName(s)[0];
             if (d.getElementById(id)) {return;}

--- a/packages/ksf-login/src/KSF/Login/Facebook/Sdk.js
+++ b/packages/ksf-login/src/KSF/Login/Facebook/Sdk.js
@@ -45,14 +45,14 @@ exports._api = function(fb, path, method, params, callback) {
 exports._init = function(callback) {
   return function(fbConfig) {
     return function() { // returns an effect
-      if (window.isFBLoaded || typeof FB === 'object') {
-        callback(FB)();
+      if (window.isFBLoaded || window.FB && typeof window.FB === 'object') {
+        callback(window.FB)();
       } else {
         window.fbAsyncInit = function() {
-          FB.init(fbConfig);
-          FB.AppEvents.logPageView();
+          window.FB.init(fbConfig);
+          window.FB.AppEvents.logPageView();
           window.isFBLoaded = true;
-          callback(FB)(); // callback itself returns an effect
+          callback(window.FB)(); // callback itself returns an effect
         };
         (function(d, s, id){
           var js, fjs = d.getElementsByTagName(s)[0];


### PR DESCRIPTION
If the Facebook SDK is already loaded to the site, loading and initializing it the second time will cause the SDK to break.

Fixes #44 