### PR TITLE
Add elections to deploy.rb, restructure env_variables

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -1,29 +1,46 @@
-env_variables = %w[
-  PRODUCTION_JANRAIN_LOGIN_CLIENT_ID
-  PRODUCTION_JANRAIN_SSO_SERVER
-  PRODUCTION_JANRAIN_FLOW_VERSION
-  PRODUCTION_JANRAIN_XD_RECEIVER_PATH
-  PRODUCTION_PERSONA_URL
-  PRODUCTION_GOOGLE_CLIENT_ID
-  PRODUCTION_FACEBOOK_APP_ID
-]
+# Common env variables groupped by their purpose
+env_variables = {
+  "social_login" => %w[
+    PRODUCTION_JANRAIN_LOGIN_CLIENT_ID
+    PRODUCTION_JANRAIN_SSO_SERVER
+    PRODUCTION_JANRAIN_FLOW_VERSION
+    PRODUCTION_JANRAIN_XD_RECEIVER_PATH
+    PRODUCTION_GOOGLE_CLIENT_ID
+    PRODUCTION_FACEBOOK_APP_ID
+  ],
+  "persona" => %w[
+    PRODUCTION_PERSONA_URL
+  ]
+}
 
-apps = %w[
-  mitt-konto
-  prenumerera
-]
+# A hash of apps with their configuration
+apps = {
+  "mitt-konto" => {
+    "env_variables" =>
+    env_variables["social_login"] +
+    env_variables["persona"]
+  },
+  "prenumerera" => {
+    "env_variables" =>
+    env_variables["social_login"] +
+    env_variables["persona"]
+  },
+  "elections" => {
+    "env_variables" => %w[]
+  }
+}
 
 app_name = ARGV.first
 
-abort("Invalid app name: #{app_name}") if !apps.include?(app_name)
+abort("Invalid app name: #{app_name}") if !apps.keys.include?(app_name)
 
 if ENV['HEAD'] == 'master'
-  env_variables.each do |v|
+  apps[app_name]["env_variables"].each do |v|
     abort("Did not find #{v} in the environment variables") if ENV[v].nil?
   end
 
   File.open("apps/#{app_name}/.env.production", 'a') do |f|
-    env_variables.each do |v|
+    apps[app_name]["env_variables"].each do |v|
       # Strip 'PRODUCTION_' from the variable name
       env_var_name = v.sub(/^PRODUCTION_/, '')
       f.puts("#{env_var_name}=#{ENV[v]}")


### PR DESCRIPTION
I only added `elections` to a list of `apps`. The script would have
failed if any of the `env_variables` weren't defined. We don't need
any of existing variables in the `elections`, but we'll soon need some
other ones (the backend URL I suppose).

Instead of having a list of `apps` and a global list of
`env_variables` I made an object where app names are keys
and their env variables are in the values (possibly with
some other configuration in the future).

TIL ruby, WAAAAAT :D