### PR TITLE
ksf-login: handle the situation in which sso library is not loaded

### DIFF
--- a/packages/ksf-login/src/JanrainSSO.js
+++ b/packages/ksf-login/src/JanrainSSO.js
@@ -1,4 +1,4 @@
-exports.sso = JANRAIN.SSO;
+exports.sso = window.JANRAIN ? window.JANRAIN.SSO : null;
 
 exports.loadConfig = function() {
   var baseUrl = window.location.protocol + "//" + window.location.host;
@@ -12,5 +12,5 @@ exports.loadConfig = function() {
     xd_receiver: baseUrl + process.env.JANRAIN_XD_RECEIVER_PATH
   };
   console.log("SSO config", config);
-  return config;
+  return window.JANRAIN ? config : null;
 }

--- a/packages/ksf-login/src/JanrainSSO.purs
+++ b/packages/ksf-login/src/JanrainSSO.purs
@@ -15,7 +15,7 @@ import Effect.Uncurried (EffectFn1, runEffectFn1)
 import LocalStorage as LocalStorage
 import Unsafe.Coerce (unsafeCoerce)
 
-foreign import loadConfig :: Effect Config
+foreign import loadConfig :: Effect (Nullable Config)
 
 setSsoSuccess :: Effect Unit
 setSsoSuccess = do


### PR DESCRIPTION
The `window.JANRAIN` won't be defined then and we shouldn't be trying to do anything with it.