### PR TITLE
Add uglify-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ All assets are shared by all packages and apps:
 
 ### Production build
 
+#### Apps
+
+For building and deploying single page applications from `apps/`, the `deploy.rb` script is used.
 ```
 $ ruby deploy.rb $APP_NAME
 ```
+
+#### Scripts
+
+For static scripts, the build command is defined in Netlify. In this case, we just want to minify all content under `scripts/`.
+```
+# A simple one-liner to minify all js files
+ruby -e 'Dir.glob("scripts/**/*.js").each { |f| `uglifyjs #{f} -o #{f.gsub(/js\z/, "min.js")}` }'
+```
+Here, for example, a file `scripts/apps/appScript.js` is minified to `scripts/apps/appScript.min.js`.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "parcel-bundler": "^1.10.3",
     "purescript": "^0.13.2",
     "spago": "^0.9.0",
-    "yarn": "^1.17.3"
+    "yarn": "^1.17.3",
+    "uglify-js": "^3.6.0"
   },
   "bootstrap": {
     "useWorkspaces": true,


### PR DESCRIPTION
Adds `uglify-js` for minifying javascript on deploy.

The deploy minifies javascript files under `script/`. For each js file, the deploy creates a file called `xxxx.min.js` to the same directory where the original file is.