### PR TITLE
Prevent overflow in article container

### DIFF
--- a/apps/app-article/src/index.css
+++ b/apps/app-article/src/index.css
@@ -439,3 +439,7 @@ body {
     width: 100%;
     height:196px;
 }
+
+.container-fluid.article {
+    overflow-x: hidden;
+}

--- a/apps/app-article/src/index.css
+++ b/apps/app-article/src/index.css
@@ -437,7 +437,6 @@ body {
 
 .html iframe {
     width: 100%;
-    height:196px;
 }
 
 .container-fluid.article {


### PR DESCRIPTION
To make double sure there is no sideways scrolling an overflow-x is in place. Also removing that pesky height form the iframe. It somehow sneaked back into the index.css.