### PR TITLE
Add possibility to deploy a maintenance page

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -40,6 +40,7 @@ apps = {
 }
 
 app_name = ARGV.first
+maintenance = ARGV[1]
 
 abort("Invalid app name: #{app_name}") if !apps.keys.include?(app_name)
 
@@ -72,4 +73,13 @@ build_commands = [
   "yarn --cwd './apps/#{app_name}/' run build"
 ]
 
-build_commands.each { |c| run_command(c) }
+def deploy_maintenance_page(app_name)
+  run_command("mkdir -p ./apps/#{app_name}/dist && cp ./static/maintenance.html ./apps/#{app_name}/dist/index.html")
+end
+
+if maintenance == '--maintenance'
+  puts 'Depolying maintenance page'
+  deploy_maintenance_page(app_name)
+else
+  build_commands.each { |c| run_command(c) }
+end

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -1,0 +1,7 @@
+<h1>Hej!</h1>
+<p>Denna webbplats <strong>uppdateras</strong> idag klockan 17.30.
+    Serviceavbrottet beräknas vara klar inom 5 timmar.
+    Under tiden är tjänsten inte i bruk.
+    Vi beklagar eventuella olägenheter.
+</p>
+<h4>Med vänlig hälsning, KSF Media AB</h4>


### PR DESCRIPTION
Whenever running the deploy script as such, `ruby deploy.rb mitt-konto --maintenance`, a maintenance page is showed.