### PR TITLE
Hide set password form when user already set the password

### DIFF
--- a/apps/mitt-konto/.build-size-sha256
+++ b/apps/mitt-konto/.build-size-sha256
@@ -1,3 +1,3 @@
 # SHA256 of the content of the build directory.
 # This is used for triggering project deployment when there are updated dependecies.
-ce91a6ef101ea0cac2e70dbcb4cc18cbb559b9d3b9bedfbde41d73dc8c744d35
+e0ee7141bcd44a581704548f1dc7e77811e62090539481956c109e7b2609731c

--- a/apps/prenumerera/.build-size-sha256
+++ b/apps/prenumerera/.build-size-sha256
@@ -1,3 +1,3 @@
 # SHA256 of the content of the build directory.
 # This is used for triggering project deployment when there are updated dependecies.
-df2c103c03108bee149d6814f2ae1337c1e173083af4755df4ecf4ba31454ccd
+3b88be3839b2ec30ac6c71a648b1959e1700df5bfd5eed40808e54ea646717a5

--- a/apps/vetrina/.build-size-sha256
+++ b/apps/vetrina/.build-size-sha256
@@ -1,3 +1,3 @@
 # SHA256 of the content of the build directory.
 # This is used for triggering project deployment when there are updated dependecies.
-cacfe1e663d631b6f2a237d3688556055d7a1f79b1cc9b1a0dd95495e8a2ec7c
+7e8253082792ec78450cf5b3022b29c4355b5f7462815fc33900b829b240c07b

--- a/apps/vetrina/src/Vetrina/Main.purs
+++ b/apps/vetrina/src/Vetrina/Main.purs
@@ -142,7 +142,6 @@ didMount self = do
       do
         -- Try to login with local storage information and set user to state
         User.magicLogin (Just InvalidateCache) $ hush >>> \maybeUser -> self.setState _ { user = maybeUser }
-
         packages <- User.getPackages
         let (Tuple invalidProducts validProducts) =
               map (Product.toProduct packages) productsToShow # partitionValidProducts
@@ -319,13 +318,10 @@ passwordInput self = InputField.inputField
       Form.validateField ExistingPassword self.state.form.existingPassword []
   }
 
-setLoading :: Maybe Spinner.Loading -> State -> State
-setLoading loading = _ { isLoading = loading }
-
 submitNewOrderForm :: Self -> Form.ValidatedForm NewAccountInputField NewAccountForm -> Effect Unit
 submitNewOrderForm self@{ state: { form, logger } } = unV
   (\errors -> self.setState _ { form { emailAddress = form.emailAddress <|> Just "" } })
-  (\validForm -> Aff.launchAff_ $ Spinner.withSpinner (self.setState <<< setLoading) do
+  (\validForm -> Aff.launchAff_ $ Spinner.withSpinner (self.setState <<< Spinner.setSpinner) do
       eitherRes <- runExceptT do
         -- If user is found in state, clearly they already have an accout and are logged in
         user <- ExceptT $ case self.state.user of

--- a/apps/vetrina/src/Vetrina/Main.purs
+++ b/apps/vetrina/src/Vetrina/Main.purs
@@ -19,6 +19,7 @@ import Effect.Aff (Aff)
 import Effect.Aff as Aff
 import Effect.Class (liftEffect)
 import Effect.Exception (error, message)
+import KSF.Api (InvalidateCache(..))
 import KSF.Api.Package (PackageName(..), PackageValidationError(..), Package)
 import KSF.Api.Package as Package
 import KSF.InputField.Component as InputField
@@ -140,7 +141,7 @@ didMount self = do
       (liftEffect $ self.setState \s -> s { isLoading = Nothing })
       do
         -- Try to login with local storage information and set user to state
-        User.magicLogin $ hush >>> \maybeUser -> self.setState _ { user = maybeUser }
+        User.magicLogin (Just InvalidateCache) $ hush >>> \maybeUser -> self.setState _ { user = maybeUser }
 
         packages <- User.getPackages
         let (Tuple invalidProducts validProducts) =

--- a/apps/vetrina/src/Vetrina/Purchase/Completed.purs
+++ b/apps/vetrina/src/Vetrina/Purchase/Completed.purs
@@ -37,6 +37,7 @@ completed :: Props -> JSX
 completed = make component
   { initialState: { passwordForm: { newPassword: Nothing, confirmPassword: Nothing }, user: Nothing }
   , render
+  , didMount
   }
 
 type PasswordForm =
@@ -66,7 +67,7 @@ render self =
     , children:
         [ DOM.h1_ [ DOM.text "Tack för din prenumeration!" ]
         , DOM.p_ [ DOM.text "Vi har skickat en prenumerationsbekräftelse och instruktioner om hur du tar i bruk våra digitala tjänster till din e-postadress. (Kolla vid behov också i skräppostmappen.)" ]
-        , case self.props.user of
+        , case self.state.user of
              Just u | not u.hasCompletedRegistration -> setPassword self
              _ -> completeButton self
         ]
@@ -132,7 +133,7 @@ submitNewPassword self@{ state: { passwordForm } } form =
           eitherUser <- User.updatePassword user.uuid (Password password) (Password password)
           liftEffect $ case eitherUser of
             Left err -> self.props.onError err
-            Right u -> self.setState _ { user = Just u }
+            Right u  -> self.setState _ { user = Just u }
         | otherwise ->
           self.props.logger.log "Purchase.Completed: Tried to submit invalid password form" Sentry.Warning
 

--- a/apps/vetrina/src/Vetrina/Purchase/Completed.purs
+++ b/apps/vetrina/src/Vetrina/Purchase/Completed.purs
@@ -128,9 +128,9 @@ submitNewPassword self@{ state: { passwordForm } } form =
       Right validForm
         | Just user <- self.props.user
         , Just password <- validForm.newPassword
-        , Just confirmPasword <- validForm.confirmPassword
+        , Just confirmPassword <- validForm.confirmPassword
         -> Aff.launchAff_ do
-          eitherUser <- User.updatePassword user.uuid (Password password) (Password password)
+          eitherUser <- User.updatePassword user.uuid (Password password) (Password confirmPassword)
           liftEffect $ case eitherUser of
             Left err -> self.props.onError err
             Right u  -> self.setState _ { user = Just u }

--- a/apps/vetrina/src/Vetrina/Purchase/Completed.purs
+++ b/apps/vetrina/src/Vetrina/Purchase/Completed.purs
@@ -6,7 +6,6 @@ import Control.Alt ((<|>))
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..), isJust, isNothing)
 import Effect (Effect)
-import Effect.Aff (Aff)
 import Effect.Aff as Aff
 import Effect.Class (liftEffect)
 import KSF.Api (Password(..))

--- a/packages/components/src/Api.purs
+++ b/packages/components/src/Api.purs
@@ -16,6 +16,11 @@ derive newtype instance writeforeignToken :: WriteForeign Token
 
 newtype Password = Password String
 
+data InvalidateCache = InvalidateCache
+
+invalidateCacheHeader :: InvalidateCache -> String
+invalidateCacheHeader _ = "max-age=0"
+
 oauthToken :: Token -> String
 oauthToken (Token token) = "OAuth " <> token
 

--- a/packages/components/src/Persona.purs
+++ b/packages/components/src/Persona.purs
@@ -12,7 +12,7 @@ import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.JSDate (JSDate)
 import Data.List (fromFoldable)
-import Data.Maybe (Maybe(..), isNothing)
+import Data.Maybe (Maybe(..), fromMaybe, isNothing)
 import Data.Nullable (Nullable, toNullable)
 import Data.String (toLower)
 import Data.String.Read (class Read)
@@ -23,10 +23,9 @@ import Foreign (Foreign, readNullOrUndefined, unsafeToForeign)
 import Foreign.Generic.EnumEncoding (defaultGenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
 import Foreign.Index (readProp) as Foreign
 import Foreign.Object (Object)
-import KSF.Api (InvalidateCache(..), Password(..), Token(..), UUID, invalidateCacheHeader)
+import KSF.Api (InvalidateCache, Password, Token(..), UUID, invalidateCacheHeader)
 import KSF.Api.Package (Package, Campaign)
 import OpenApiClient (Api, callApi)
-import Record (merge)
 import Simple.JSON (class ReadForeign, class WriteForeign, readImpl)
 import Simple.JSON as JSON
 
@@ -47,9 +46,9 @@ getUser invalidateCache uuid token =
   callApi usersApi "usersUuidGet" [ unsafeToForeign uuid ] headers
   where
     headers =
-      { authorization } `merge` case maybeCacheControl of
-        Just cacheControl -> { cacheControl }
-        Nothing           -> mempty
+      { authorization
+      , cacheControl: fromMaybe mempty maybeCacheControl
+      }
     authorization = oauthToken token
     maybeCacheControl = invalidateCacheHeader <$> invalidateCache
 

--- a/packages/components/src/Spinner.purs
+++ b/packages/components/src/Spinner.purs
@@ -54,3 +54,6 @@ loadingSpinner =
             }
         ]
     }
+
+setSpinner :: forall r. Maybe Loading -> { isLoading :: Maybe Loading | r } -> { isLoading :: Maybe Loading | r }
+setSpinner loading = _ { isLoading = loading }

--- a/packages/user/src/User/Login.purs
+++ b/packages/user/src/User/Login.purs
@@ -168,7 +168,7 @@ login = make component
 
 didMount :: Self -> Effect Unit
 didMount self@{ props, state } = do
-  props.launchAff_ $ User.magicLogin \user -> do
+  props.launchAff_ $ User.magicLogin Nothing \user -> do
     case user of
       Left _ -> self.setState _ { errors { login = Just SomethingWentWrong } }
       Right _ -> pure unit
@@ -440,7 +440,7 @@ googleLogin self =
       -- setting the email in the state to eventually have it in the merge view
       liftEffect $ self.setState _ { formEmail = Just email }
 
-      user <- User.someAuth self.state.merge (User.Email email) (User.Token accessToken) User.GooglePlus
+      user <- User.someAuth Nothing self.state.merge (User.Email email) (User.Token accessToken) User.GooglePlus
       finalizeSomeAuth self user
       liftEffect $ self.props.onUserFetch user
 
@@ -506,7 +506,7 @@ facebookLogin self =
       -- setting the email in the state to eventually send it from the merge view form
       liftEffect $ self.setState _ { formEmail = Just email }
       let (FB.AccessToken fbAccessToken) = accessToken
-      user <- User.someAuth self.state.merge (User.Email email) (User.Token fbAccessToken) User.Facebook
+      user <- User.someAuth Nothing self.state.merge (User.Email email) (User.Token fbAccessToken) User.Facebook
       finalizeSomeAuth self user
       liftEffect $ self.props.onUserFetch user
 


### PR DESCRIPTION
This was just a problem of casing against `props.user` instead of `state.user` (#297). Fixed a couple of other things as well:

- add CacheControl header to the `getUser` call -> we need to fetch a fresh user when mounting Vetrina
- add loading spinner when setting the password
- actually send the `confirmPassword` value to the server
