### PR TITLE
Add Sentry to mitt-konto

### DIFF
--- a/apps/mitt-konto/.build-size-sha256
+++ b/apps/mitt-konto/.build-size-sha256
@@ -1,3 +1,3 @@
 # SHA256 of the content of the build directory.
 # This is used for triggering project deployment when there are updated dependecies.
-fa64ebd7ad4969203c84c608c98106d8ff87ad98a9f05cd83567b17e248144c0
+d03eecb2f6842e170646976458e766009ca941cf5c520d8f84ebfb93c910ded8

--- a/apps/mitt-konto/.env.development
+++ b/apps/mitt-konto/.env.development
@@ -5,3 +5,4 @@ JANRAIN_XD_RECEIVER_PATH=/xd_receiver.html
 PERSONA_URL=https://persona.staging.ksfmedia.fi/v1
 GOOGLE_CLIENT_ID=485787859358-slq0hnm3n8ps3catfi2q93s710ges3tj
 FACEBOOK_APP_ID=842392522540268
+SENTRY_DSN=

--- a/apps/mitt-konto/src/MittKonto/Main.js
+++ b/apps/mitt-konto/src/MittKonto/Main.js
@@ -1,3 +1,6 @@
 exports.images = {
   subscribe: require('../../../../images/offer-cta.png')
 };
+exports.sentryDsn_ = function() {
+  return process.env.SENTRY_DSN;
+};

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -197,6 +197,7 @@ userView { setState, state: { logger } } user = React.fragment
         profileComponentBlock = componentBlockContent $ Profile.profile
           { profile: user
           , onUpdate: setState <<< setLoggedInUser <<< Just
+          , logger
           }
 
     subscriptionsView =

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -176,7 +176,7 @@ footerView = Footer.footer {}
 
 -- | User info page with profile info, subscriptions, etc.
 userView :: Self -> User -> JSX
-userView { setState } user = React.fragment
+userView { setState, state: { logger } } user = React.fragment
   [ classy DOM.div "col col-12 md-col-6 lg-col-6 mitt-konto--profile" [ profileView ]
   , classy DOM.div "col col-12 md-col-6 lg-col-6" [ subscriptionsView ]
   ]
@@ -209,7 +209,7 @@ userView { setState } user = React.fragment
             subs -> do
               map subscriptionComponentBlockContent subs `snoc` cancelSubscription
               where
-                subscriptionView subscription = Subscription.subscription { subscription, user }
+                subscriptionView subscription = Subscription.subscription { subscription, user, logger }
                 subscriptionComponentBlockContent subscription
                   -- If the subscription has a canceled state, we want to add extra css to it.
                   | Subscription.isSubscriptionCanceled subscription =

--- a/packages/components/src/Api/Subscription.purs
+++ b/packages/components/src/Api/Subscription.purs
@@ -1,0 +1,78 @@
+module KSF.Api.Subscription where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Generic.Rep (class Generic)
+import Data.JSDate (JSDate)
+import Data.Nullable (Nullable)
+import KSF.Api.Package (Package, Campaign)
+import Simple.JSON (class ReadForeign, readImpl)
+
+
+type DeliveryAddress =
+  { streetAddress :: Nullable String
+  , zipcode       :: String
+  , city          :: Nullable String
+  , temporaryName :: Nullable String
+  }
+
+type PendingAddressChange =
+  { address   :: DeliveryAddress
+  , startDate :: JSDate
+  , endDate   :: JSDate
+  }
+
+type Subscription =
+  { subsno                :: Int
+  , extno                 :: Int
+  , cusno                 :: Int
+  , paycusno              :: Int
+  , kind                  :: String
+  , state                 :: SubscriptionState
+  , pricegroup            :: String
+  , package               :: Package
+  , dates                 :: SubscriptionDates
+  , campaign              :: Campaign
+  , paused                :: Nullable (Array PausedSubscription)
+  , deliveryAddress       :: Nullable DeliveryAddress
+  , pendingAddressChanges :: Nullable (Array PendingAddressChange)
+  }
+
+
+type PausedSubscription =
+  { startDate :: JSDate
+  , endDate   :: Nullable JSDate
+  }
+
+newtype SubscriptionState = SubscriptionState String
+
+derive instance genericSubscriptionState :: Generic SubscriptionState _
+instance readForeignSubscriptionState :: ReadForeign SubscriptionState where
+  readImpl f = map SubscriptionState (readImpl f)
+derive instance eqSubscriptionState :: Eq SubscriptionState
+instance ordSubscriptionState :: Ord SubscriptionState where
+  compare =
+    comparing
+      \s@(SubscriptionState st) ->
+        if isSubscriptionStateCanceled s
+        then Right st
+        else Left st
+
+type SubscriptionDates =
+  { lenMonths           :: Nullable Int
+  , lenDays             :: Nullable Int
+  , start               :: JSDate
+  , end                 :: Nullable JSDate
+  , unpaidBreak         :: Nullable JSDate
+  , invoicingStart      :: Nullable JSDate
+  , paidUntil           :: Nullable JSDate
+  , suspend             :: Nullable JSDate
+  }
+
+isSubscriptionCanceled :: Subscription -> Boolean
+isSubscriptionCanceled s = isSubscriptionStateCanceled s.state
+
+isSubscriptionStateCanceled :: SubscriptionState -> Boolean
+isSubscriptionStateCanceled (SubscriptionState "Canceled") = true
+isSubscriptionStateCanceled _ = false

--- a/packages/components/src/Error.purs
+++ b/packages/components/src/Error.purs
@@ -1,0 +1,40 @@
+module KSF.Error where
+
+import Prelude
+
+import Control.Monad.Except (runExcept)
+import Data.Either (hush)
+import Data.Maybe (Maybe, isNothing)
+import Control.MonadPlus (guard)
+import Data.Traversable (traverse)
+import Effect.Exception (Error)
+import Foreign (Foreign, unsafeToForeign, readNullOrUndefined)
+import Foreign.Index as Foreign
+import Simple.JSON (class ReadForeign)
+import Simple.JSON as JSON
+
+-- | Matches internal server error produced by superagent.
+--   Checks that it has `status` field that's 5XX.
+internalServerError :: Error -> Maybe { status :: Int }
+internalServerError err = do
+  status <- err # errorField "status"
+  guard $ status >= 500 && status <= 599
+  pure { status }
+
+-- | Matches network error produced by superagent.
+--   Checks that it has `method` and `url` fields, but no `status`.
+networkError :: Error -> Maybe { method :: String, url :: String }
+networkError err = do
+  method <- errorField "method" err
+  url <- errorField "url" err
+  guard $ isNothing (errorField "status" err :: Maybe Foreign)
+  pure { method, url }
+
+-- | Check if an error has some field and it's not null or undefined.
+errorField :: forall a. ReadForeign a => String -> Error -> Maybe a
+errorField field =
+  join <<< hush
+    <<< (traverse JSON.read =<< _)
+    <<< runExcept
+    <<< do readNullOrUndefined <=< Foreign.readProp field
+    <<< unsafeToForeign

--- a/packages/components/src/JSError.js
+++ b/packages/components/src/JSError.js
@@ -14,6 +14,10 @@ exports.subscriptionError_ = function(message) {
   return new SubscriptionError(message);
 };
 
+exports.userError = function(message) {
+  return new UserError(message);
+}
+
 class OrderError extends Error {
   constructor(message) {
     super(message);
@@ -39,5 +43,12 @@ class SubscriptionError extends Error {
   constructor(message) {
     super(message);
     this.name = 'SubscriptionError';
+  }
+}
+
+class UserError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'UserError';
   }
 }

--- a/packages/components/src/JSError.js
+++ b/packages/components/src/JSError.js
@@ -1,14 +1,18 @@
 exports.orderError = function(message) {
-    return new OrderError(message);
+  return new OrderError(message);
 };
 
 exports.packageError = function(message) {
-    return new PackageError(message);
+  return new PackageError(message);
 };
 
 exports.loginError = function(message) {
-    return new LoginError(message);
-}
+  return new LoginError(message);
+};
+
+exports.subscriptionError_ = function(message) {
+  return new SubscriptionError(message);
+};
 
 class OrderError extends Error {
   constructor(message) {
@@ -28,5 +32,12 @@ class LoginError extends Error {
   constructor(message) {
     super(message);
     this.name = 'LoginError';
+  }
+}
+
+class SubscriptionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'SubscriptionError';
   }
 }

--- a/packages/components/src/JSError.purs
+++ b/packages/components/src/JSError.purs
@@ -1,7 +1,24 @@
 module KSF.JSError where
 
+import Prelude
+
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Effect.Exception (Error)
 
-foreign import packageError :: String -> Error
-foreign import orderError   :: String -> Error
-foreign import loginError   :: String -> Error
+foreign import packageError       :: String -> Error
+foreign import orderError         :: String -> Error
+foreign import loginError         :: String -> Error
+foreign import subscriptionError_ :: String -> Error
+
+data SubscriptionError
+  = SubscriptionTemporaryAddressChange
+  | SubscriptionPause
+  | SubscriptionReclamation
+
+derive instance genericSubscriptionError :: Generic SubscriptionError _
+instance showSubscriptionError :: Show SubscriptionError where
+  show = genericShow
+
+subscriptionError :: SubscriptionError -> String -> Error
+subscriptionError subsErr errMsg = subscriptionError_ $ (show subsErr) <> ": " <> errMsg

--- a/packages/components/src/JSError.purs
+++ b/packages/components/src/JSError.purs
@@ -10,6 +10,7 @@ foreign import packageError       :: String -> Error
 foreign import orderError         :: String -> Error
 foreign import loginError         :: String -> Error
 foreign import subscriptionError_ :: String -> Error
+foreign import userError          :: String -> Error
 
 data SubscriptionError
   = SubscriptionTemporaryAddressChange

--- a/packages/components/src/Persona.purs
+++ b/packages/components/src/Persona.purs
@@ -247,6 +247,8 @@ data InvalidDateInput
 derive instance genericInvaliDateInput :: Generic InvalidDateInput _
 instance readInvalidDateInput :: ReadForeign InvalidDateInput where
   readImpl a = genericDecodeEnum defaultGenericEnumOptions a <|> pure InvalidUnexpected
+instance showSubscriptionError :: Show InvalidDateInput where
+  show = genericShow
 
 type InvalidDates = PersonaError
   ( invalid_param ::

--- a/packages/components/src/Persona.purs
+++ b/packages/components/src/Persona.purs
@@ -4,29 +4,27 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Control.Monad.Except (runExcept)
-import Control.MonadPlus (guard)
 import Data.DateTime (DateTime)
-import Data.Either (Either(..), hush)
+import Data.Either (hush)
 import Data.Formatter.DateTime (FormatterCommand(..), format)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.JSDate (JSDate)
 import Data.List (fromFoldable)
-import Data.Maybe (Maybe(..), isNothing)
+import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable, toNullable)
 import Data.String (toLower)
 import Data.String.Read (class Read)
-import Data.Traversable (traverse)
 import Effect.Aff (Aff)
 import Effect.Exception (Error)
-import Foreign (Foreign, readNullOrUndefined, unsafeToForeign)
+import Foreign (unsafeToForeign)
 import Foreign.Generic.EnumEncoding (defaultGenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
 import Foreign.Index (readProp) as Foreign
 import Foreign.Object (Object)
 import KSF.Api (InvalidateCache, Password, Token(..), UUID, invalidateCacheHeader)
-import KSF.Api.Package (Package, Campaign)
+import KSF.Api.Subscription (Subscription, PendingAddressChange)
 import OpenApiClient (Api, callApi)
-import Simple.JSON (class ReadForeign, class WriteForeign, readImpl)
+import Simple.JSON (class ReadForeign, class WriteForeign)
 import Simple.JSON as JSON
 
 foreign import loginApi :: Api
@@ -279,38 +277,7 @@ errorData =
           <<< Foreign.readProp "data"
           <<< unsafeToForeign
 
--- | Matches internal server error produced by superagent.
---   Checks that it has `status` field that's 5XX.
-internalServerError :: Error -> Maybe { status :: Int }
-internalServerError err = do
-  status <- err # errorField "status"
-  guard $ status >= 500 && status <= 599
-  pure { status }
 
--- | Matches network error produced by superagent.
---   Checks that it has `method` and `url` fields, but no `status`.
-networkError :: Error -> Maybe { method :: String, url :: String }
-networkError err = do
-  method <- errorField "method" err
-  url <- errorField "url" err
-  guard $ isNothing (errorField "status" err :: Maybe Foreign)
-  pure { method, url }
-
--- | Check if an error has some field and it's not null or undefined.
-errorField :: forall a. ReadForeign a => String -> Error -> Maybe a
-errorField field =
-  join <<< hush
-    <<< (traverse JSON.read =<< _)
-    <<< runExcept
-    <<< do readNullOrUndefined <=< Foreign.readProp field
-    <<< unsafeToForeign
-
-isSubscriptionCanceled :: Subscription -> Boolean
-isSubscriptionCanceled s = isSubscriptionStateCanceled s.state
-
-isSubscriptionStateCanceled :: SubscriptionState -> Boolean
-isSubscriptionStateCanceled (SubscriptionState "Canceled") = true
-isSubscriptionStateCanceled _ = false
 
 data Provider
   = Facebook
@@ -365,65 +332,6 @@ type Address =
   , houseNo       :: Nullable String
   , staircase     :: Nullable String
   , apartment     :: Nullable String
-  }
-
-type DeliveryAddress =
-  { streetAddress :: Nullable String
-  , zipcode       :: String
-  , city          :: Nullable String
-  , temporaryName :: Nullable String
-  }
-
-type PendingAddressChange =
-  { address   :: DeliveryAddress
-  , startDate :: JSDate
-  , endDate   :: JSDate
-  }
-
-type Subscription =
-  { subsno                :: Int
-  , extno                 :: Int
-  , cusno                 :: Int
-  , paycusno              :: Int
-  , kind                  :: String
-  , state                 :: SubscriptionState
-  , pricegroup            :: String
-  , package               :: Package
-  , dates                 :: SubscriptionDates
-  , campaign              :: Campaign
-  , paused                :: Nullable (Array PausedSubscription)
-  , deliveryAddress       :: Nullable DeliveryAddress
-  , pendingAddressChanges :: Nullable (Array PendingAddressChange)
-  }
-
-type PausedSubscription =
-  { startDate :: JSDate
-  , endDate   :: Nullable JSDate
-  }
-
-newtype SubscriptionState = SubscriptionState String
-
-derive instance genericSubscriptionState :: Generic SubscriptionState _
-instance readForeignSubscriptionState :: ReadForeign SubscriptionState where
-  readImpl f = map SubscriptionState (readImpl f)
-derive instance eqSubscriptionState :: Eq SubscriptionState
-instance ordSubscriptionState :: Ord SubscriptionState where
-  compare =
-    comparing
-      \s@(SubscriptionState st) ->
-        if isSubscriptionStateCanceled s
-        then Right st
-        else Left st
-
-type SubscriptionDates =
-  { lenMonths           :: Nullable Int
-  , lenDays             :: Nullable Int
-  , start               :: JSDate
-  , end                 :: Nullable JSDate
-  , unpaidBreak         :: Nullable JSDate
-  , invoicingStart      :: Nullable JSDate
-  , paidUntil           :: Nullable JSDate
-  , suspend             :: Nullable JSDate
   }
 
 type GdprConsent =

--- a/packages/components/src/Profile/Component.purs
+++ b/packages/components/src/Profile/Component.purs
@@ -28,6 +28,8 @@ import KSF.AsyncWrapper as AsyncWrapper
 import KSF.CountryDropDown as CountryDropDown
 import KSF.DescriptionList.Component as DescriptionList
 import KSF.InputField.Component as InputField
+import KSF.JSError as Error
+import KSF.Sentry as Sentry
 import KSF.User (User)
 import KSF.User as User
 import KSF.ValidatableForm (class ValidatableField, ValidatedForm, inputFieldErrorMessage, validateEmptyField, validateField, validateZipCode)
@@ -42,6 +44,7 @@ type Self = React.Self Props State
 type Props =
   { profile :: User
   , onUpdate :: User -> Effect Unit
+  , logger :: Sentry.Logger
   }
 
 type State =
@@ -314,9 +317,9 @@ editAddress self =
             self.props.onUpdate u
             self.setState _ { editAddress = Success Nothing }
           Left err -> do
-            Console.error "Unexpected error when updating name."
-            liftEffect $ self.setState _ { editName = AsyncWrapper.Error "Adressändringen misslyckades." }
-            throwError $ error "Unexpected error when updating name."
+            liftEffect do
+              self.props.logger.error $ Error.userError $ show err
+              self.setState _ { editName = AsyncWrapper.Error "Adressändringen misslyckades." }
     updateAddress _ = pure unit
 
 editName :: Self -> JSX
@@ -372,8 +375,9 @@ editName self =
               self.props.onUpdate u
               self.setState _ { editName = Success Nothing }
             Left err -> do
-              Console.error "Unexpected error when updating name."
-              liftEffect $ self.setState _ { editName = AsyncWrapper.Error "Namnändringen misslyckades." }
+              liftEffect do
+                self.props.logger.error $ Error.userError $ show err
+                self.setState _ { editName = AsyncWrapper.Error "Namnändringen misslyckades." }
               throwError $ error "Unexpected error when updating name."
       updateName _ = pure unit
 

--- a/packages/components/src/Subscription/Component.purs
+++ b/packages/components/src/Subscription/Component.purs
@@ -94,6 +94,7 @@ didMount self = do
     , pausedSubscriptions = toMaybe self.props.subscription.paused
     , pendingAddressChanges = toMaybe self.props.subscription.pendingAddressChanges
     }
+  self.props.logger.setUser $ Just self.props.user
 
 render :: Self -> JSX
 render self@{ props: props@{ subscription: sub@{ package } } } =

--- a/packages/components/src/Subscription/Component.purs
+++ b/packages/components/src/Subscription/Component.purs
@@ -13,16 +13,18 @@ import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Nullable (toMaybe)
 import Data.String (trim)
 import Effect (Effect)
+import Effect.Class.Console as Console
 import Effect.Now as Now
 import KSF.AsyncWrapper as AsyncWrapper
+import KSF.DeliveryReclamation as DeliveryReclamation
 import KSF.DescriptionList.Component as DescriptionList
 import KSF.Grid as Grid
+import KSF.JSError as Error
 import KSF.PauseSubscription.Component as PauseSubscription
+import KSF.Sentry as Sentry
 import KSF.TemporaryAddressChange.Component as TemporaryAddressChange
-import KSF.DeliveryReclamation as DeliveryReclamation
-
-import KSF.User as User
 import KSF.User (User, InvalidDateInput(..))
+import KSF.User as User
 import React.Basic (JSX, make)
 import React.Basic as React
 import React.Basic.DOM as DOM
@@ -33,6 +35,7 @@ type Self = React.Self Props State
 type Props =
   { subscription :: User.Subscription
   , user :: User
+  , logger :: Sentry.Logger
   }
 
 type State =
@@ -201,7 +204,7 @@ render self@{ props: props@{ subscription: sub@{ package } } } =
                          , wrapperProgress = AsyncWrapper.Success successText
                          }
 
-        , onError: \(err :: User.InvalidDateInput) ->
+        , onError: \(err :: User.InvalidDateInput) -> do
               let unexpectedError = "Något gick fel och vi kunde tyvärr inte genomföra den aktivitet du försökte utföra. Vänligen kontakta vår kundtjänst."
                   startDateError = "Din begäran om tillfällig adressändring i beställningen misslyckades. Tillfällig adressändring kan endast påbörjas fr.o.m. följande dag."
                   lengthError = "Din begäran om tillfällig adressändring i beställningen misslyckades, eftersom tillfällig adressändring perioden är för kort. Adressändringperioden bör vara åtminstone 7 dagar långt."
@@ -209,7 +212,9 @@ render self@{ props: props@{ subscription: sub@{ package } } } =
                     InvalidStartDate   -> startDateError
                     InvalidLength      -> lengthError
                     _                  -> unexpectedError
-              in self.setState _ { wrapperProgress = AsyncWrapper.Error errMsg }
+              self.props.logger.error
+                $ Error.subscriptionError Error.SubscriptionTemporaryAddressChange $ show err
+              self.setState _ { wrapperProgress = AsyncWrapper.Error errMsg }
         }
 
     pauseSubscriptionComponent =
@@ -224,7 +229,7 @@ render self@{ props: props@{ subscription: sub@{ package } } } =
                            , wrapperProgress = AsyncWrapper.Success successText
                            }
 
-          , onError: \err ->
+          , onError: \err -> do
               let unexpectedError = "Något gick fel och vi kunde tyvärr inte genomföra den aktivitet du försökte utföra. Vänligen kontakta vår kundtjänst."
                   startDateError = "Din begäran om uppehåll i beställningen misslyckades. Uppehåll kan endast påbörjas fr.o.m. följande dag."
                   lengthError = "Din begäran om uppehåll i beställningen misslyckades, eftersom uppehålls perioden är för kort eller lång. Uppehållsperioden bör vara mellan 7 dagar och 3 månader långt."
@@ -236,7 +241,8 @@ render self@{ props: props@{ subscription: sub@{ package } } } =
                     InvalidOverlapping -> overlappingError
                     InvalidTooRecent   -> tooRecentError
                     InvalidUnexpected  -> unexpectedError
-              in self.setState _ { wrapperProgress = AsyncWrapper.Error errMsg }
+              self.props.logger.error $ Error.subscriptionError Error.SubscriptionPause $ show err
+              self.setState _ { wrapperProgress = AsyncWrapper.Error errMsg }
           }
 
     deliveryReclamationComponent =
@@ -249,7 +255,8 @@ render self@{ props: props@{ subscription: sub@{ package } } } =
                        self.setState _
                          { wrapperProgress = AsyncWrapper.Success successText
                          }
-        , onError: \_ ->
+        , onError: \err -> do
+            self.props.logger.error $ Error.subscriptionError Error.SubscriptionReclamation $ show err
             self.setState _ { wrapperProgress = AsyncWrapper.Error "Något gick fel. Vänligen försök pånytt, eller ta kontakt med vår kundtjänst." }
         }
 

--- a/packages/components/src/Subscription/Component.purs
+++ b/packages/components/src/Subscription/Component.purs
@@ -13,7 +13,6 @@ import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Nullable (toMaybe)
 import Data.String (trim)
 import Effect (Effect)
-import Effect.Class.Console as Console
 import Effect.Now as Now
 import KSF.AsyncWrapper as AsyncWrapper
 import KSF.DeliveryReclamation as DeliveryReclamation


### PR DESCRIPTION
Will send Sentry events on
- logging in errors
- fetching user errors
- subscription action errors (pause, temporary address change, delivery reclamation)
- profile name and address errors

Also ditched `React.Compat` from `MittKonto`. Oh, also separated `Subscription` from `Persona`.

Fix #303 