### PR TITLE
Adjust Sentry levels

### DIFF
--- a/apps/mitt-konto/.build-size-sha256
+++ b/apps/mitt-konto/.build-size-sha256
@@ -1,3 +1,3 @@
 # SHA256 of the content of the build directory.
 # This is used for triggering project deployment when there are updated dependecies.
-8211a663d83a45cdcbe13a8a38d624021cbd293f460f001883ce19ff1dba93e4
+e546dab94d86015338eb2bbf6a027c316dec145eb287c54d8d1e25d24da7602f

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -13,9 +13,8 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Aff as Aff
 import Effect.Class (liftEffect)
-import Effect.Class.Console (log)
 import Effect.Class.Console as Console
-import Effect.Exception (Error, error)
+import Effect.Exception (Error, error, message)
 import Effect.Unsafe (unsafePerformEffect)
 import KSF.Alert.Component (Alert)
 import KSF.Alert.Component as Alert
@@ -156,14 +155,16 @@ withSpinner setLoadingState action = do
 
 -- | Navbar with logo, contact info, logout button, language switch, etc.
 navbarView :: Self -> JSX
-navbarView { state, setState } =
+navbarView self@{ state, setState } =
     Navbar.navbar
       { paper: state.paper
       , loggedInUser: state.loggedInUser
       , logout: do
           Aff.launchAff_ $ withSpinner (setState <<< setLoading) do
             User.logout \logoutResponse -> when (isLeft logoutResponse) $ Console.error "Logout failed"
-            liftEffect $ setState $ setLoggedInUser Nothing
+            liftEffect do
+              self.state.logger.setUser Nothing
+              setState $ setLoggedInUser Nothing
       }
 
 alertView :: Alert -> JSX

--- a/apps/mitt-konto/src/MittKonto/Main.purs
+++ b/apps/mitt-konto/src/MittKonto/Main.purs
@@ -355,7 +355,11 @@ loginView self@{ state: state@{ logger }, setState } = React.fragment
           , onUserFetch:
             case _ of
               Left err -> do
-                logger.error $ Error.loginError $ show err
+                case err of
+                  SomethingWentWrong -> logger.error $ Error.loginError $ show err
+                  UnexpectedError e  -> logger.error $ Error.loginError $ message e
+                  -- If any other UserError occurs, only send an Info event of it
+                  _ -> logger.log (show err) Sentry.Info
                 self.setState $ setLoggedInUser Nothing
               Right user -> do
                 setState $ setLoggedInUser $ Just user

--- a/packages/components/src/Sentry.js
+++ b/packages/components/src/Sentry.js
@@ -20,7 +20,8 @@ exports.setTag_ = function(sentry, key, value) {
     return sendSentryEvent(sentry, 'setTag', key, value);
 };
 exports.setUser_ = function(sentry, cusno) {
-    return sendSentryEvent(sentry, 'setUser', {id: cusno});
+    // Empty object is used for istance when user logs out from the system
+    return sendSentryEvent(sentry, 'setUser', cusno === null ? {} : {id: cusno});
 };
 
 function sendSentryEvent(sentry, fnName, ...args) {


### PR DESCRIPTION
 Only send error events when SomethingWentWrong or UnexpectedError

Remove Sentry user when logging out 