### PR TITLE
script wont build because of let. changed to var.

### DIFF
--- a/scripts/app/gamAppAds.js
+++ b/scripts/app/gamAppAds.js
@@ -185,7 +185,7 @@ var ksfDfp = {};
             divToClose.style.display = "none";
             var headerToClose = document.getElementsByClassName('ksfDFPadHeader ' + slot);
             if (typeof headerToClose[0] !== 'undefined' && headerToClose[0] != null) {
-                let unclosed = headerToClose.length - 1;
+                var unclosed = headerToClose.length - 1;
                 while(unclosed >= 0){
                      headerToClose[unclosed].style.display = "none";
                      unclosed = unclosed - 1;


### PR DESCRIPTION
The script wont build. It seems that our build script cannot understand let. Changed to var.
```
Parse error at scripts/app/gamAppAds.js:188,20
12:53:26 PM:                 let unclosed = headerToClose.length - 1;
12:53:26 PM:    
```                 ^