### PR TITLE
disable mover script as it fails sometimes in Chrome

### DIFF
--- a/apps/app-article/src/index.html
+++ b/apps/app-article/src/index.html
@@ -42,7 +42,7 @@
       ksf.settings.brand.id = "hbl";
     </script>
     <script src="https://script.ksfmedia.fi/app/gamAppAds.min.js"></script>
-    <script src="https://script.ksfmedia.fi/app/adMover.min.js"></script>
+    <!--script src="https://script.ksfmedia.fi/app/adMover.min.js"></script-->
     <!--End Google Ad-->
     <script src="https://apis.google.com/js/platform.js"></script>
 


### PR DESCRIPTION
Chrome sometimes fails to move the whole ad and creates an empty box. This is almost certainly a timing issue. Works faultlessly in Safari and mostly in FF. Must rework the mover functionality to be within the main ad script, that will proof it from timing issues.