### PR TITLE
Podcasts: more responsive menu layout

### DIFF
--- a/apps/podcasts/src/App.js
+++ b/apps/podcasts/src/App.js
@@ -62,7 +62,7 @@ class App extends React.Component {
     // JSX: Podcasts nav menu
     const podcastNav = this.state.podcasts.length > 1
       ? <nav className="pod-nav">
-          <div className="label">Välj podd</div>
+          <div className="label">Sortera enligt podd</div>
           <ul className="nav nav-lg">
             {
               this.state.podcasts.map((name, key) => {

--- a/apps/podcasts/src/App.js
+++ b/apps/podcasts/src/App.js
@@ -72,17 +72,6 @@ class App extends React.Component {
             }
             {resetListButton}
           </ul>
-          <select
-            className="nav nav-sm"
-            value={this.state.selectedPodcast}
-            onChange={e => this.selectPodcast(e.target.value)}>
-            <option value="">- Alla -</option>
-            {
-              this.state.podcasts.map((name, key) => {
-              return <option key={key} value={name}>{name}</option>
-              })
-            }
-          </select>
         </nav>
       : null
 

--- a/apps/podcasts/src/App.js
+++ b/apps/podcasts/src/App.js
@@ -11,7 +11,7 @@ class App extends React.Component {
       podAppUlr: window.pod_app_url || '',
       podcasts: [],
       tracks: [],
-      selectedPodcast: null,
+      selectedPodcast: "",
       loading: null,
       loadedPodcasts: null
     }
@@ -55,25 +55,37 @@ class App extends React.Component {
   }
 
   render() {
-    // JSX: list of podcasts
-    const podcatsList = this.state.podcasts.map((name, key) => {
-      let buttonClass = (this.state.selectedPodcast === name || !this.state.selectedPodcast) ? 'active' : '';
-      return <li className={buttonClass} onClick={() => this.selectPodcast(name)} key={key}>{name}</li>
-    });
     // JSX: Reset button to show all podcasts
     const resetListButton = this.state.selectedPodcast
-      ? <li onClick={() => {this.setState({selectedPodcast: null})}}>Se alla</li>
+      ? <li onClick={() => {this.setState({selectedPodcast: ""})}}>Se alla</li>
       : null;
     // JSX: Podcasts nav menu
     const podcastNav = this.state.podcasts.length > 1
       ? <nav className="pod-nav">
           <div className="label">Välj podd</div>
-          <ul>
-            {podcatsList}
+          <ul className="nav nav-lg">
+            {
+              this.state.podcasts.map((name, key) => {
+                let buttonClass = (this.state.selectedPodcast === name || !this.state.selectedPodcast) ? 'active' : '';
+                return <li className={buttonClass} onClick={() => this.selectPodcast(name)} key={key}>{name}</li>
+              })
+            }
             {resetListButton}
           </ul>
+          <select
+            className="nav nav-sm"
+            value={this.state.selectedPodcast}
+            onChange={e => this.selectPodcast(e.target.value)}>
+            <option value="">- Alla -</option>
+            {
+              this.state.podcasts.map((name, key) => {
+              return <option key={key} value={name}>{name}</option>
+              })
+            }
+          </select>
         </nav>
       : null
+
     // JSX: Loading indicator
     const spinner = this.state.loading === true
       ? <div className="loading">

--- a/apps/podcasts/src/App.js
+++ b/apps/podcasts/src/App.js
@@ -11,7 +11,7 @@ class App extends React.Component {
       podAppUlr: window.pod_app_url || '',
       podcasts: [],
       tracks: [],
-      selectedPodcast: "",
+      selectedPodcast: null,
       loading: null,
       loadedPodcasts: null
     }
@@ -57,7 +57,7 @@ class App extends React.Component {
   render() {
     // JSX: Reset button to show all podcasts
     const resetListButton = this.state.selectedPodcast
-      ? <li onClick={() => {this.setState({selectedPodcast: ""})}}>Se alla</li>
+      ? <li onClick={() => {this.setState({selectedPodcast: null})}}>Se alla</li>
       : null;
     // JSX: Podcasts nav menu
     const podcastNav = this.state.podcasts.length > 1

--- a/apps/podcasts/src/less/main.less
+++ b/apps/podcasts/src/less/main.less
@@ -21,42 +21,31 @@
       align-items: center;
     }
     ul {
+      display: flex;
+      flex-flow: wrap;
       list-style: none;
       margin: 0;
       padding: 0;
       li {
         text-align: center;
         justify-content: center;
-        margin: 0 1px 0 0;
+        margin: 0 5px 5px 0;
         padding: 5px;
         cursor: pointer;
         border-radius: 3px;
+        border: solid 2px #333;
         transition: all .2s;
         text-transform: uppercase;
         font-size: .875rem;
         font-family: 'Duplex Sans', sans-serif;
-        background: #e0e0e0;
+        background: #fff;
       }
       li:hover {
-        background: #a0a0a0;
-        color: #fff;
+        background: #e0e0e0;
       }
       li.active {
         background: #333;
         color: #fff;
-      }
-    }
-    .nav {
-      display: none;
-      &.nav-sm {
-        @media screen and (max-width: 767px) {
-          display: block;
-        }
-      }
-      &.nav-lg {
-        @media screen and (min-width: 768px) {
-          display: flex;
-        }
       }
     }
   }
@@ -78,7 +67,7 @@
       height: auto;
     }
     h2 {
-      margin: .875rem 0;
+      margin: .5rem 0;
       cursor: pointer;
     }
     .created {

--- a/apps/podcasts/src/less/main.less
+++ b/apps/podcasts/src/less/main.less
@@ -21,7 +21,6 @@
       align-items: center;
     }
     ul {
-      display: flex;
       list-style: none;
       margin: 0;
       padding: 0;
@@ -45,6 +44,19 @@
       li.active {
         background: #333;
         color: #fff;
+      }
+    }
+    .nav {
+      display: none;
+      &.nav-sm {
+        @media screen and (max-width: 767px) {
+          display: block;
+        }
+      }
+      &.nav-lg {
+        @media screen and (min-width: 768px) {
+          display: flex;
+        }
       }
     }
   }

--- a/apps/podcasts/src/less/main.less
+++ b/apps/podcasts/src/less/main.less
@@ -8,13 +8,12 @@
     padding-bottom: 10px;
     margin-bottom: 10px;
     border-bottom: solid 1px #e0e0e0;
-    display: flex;
     align-items: center;
     justify-content: space-between;
     .label {
       text-transform: uppercase;
       font-family: 'Duplex Sans', sans-serif;
-      padding: 5px;
+      padding: 5px 0;
       color: #a0a0a0;
       font-size: .6rem;
       display: flex;


### PR DESCRIPTION
Some tweaking, mainly the menu layout.

Old layout:
<img width="556" alt="Screenshot 2020-06-03 at 15 01 34" src="https://user-images.githubusercontent.com/6029881/83634976-1c8a3900-a5ac-11ea-8058-a4cf5018479f.png">

Changed to:
<img width="555" alt="Screenshot 2020-06-03 at 15 01 44" src="https://user-images.githubusercontent.com/6029881/83635003-2875fb00-a5ac-11ea-837a-24dd658fb2bf.png">