### PR TITLE
Show user email in landing view if firstname is not present

### DIFF
--- a/apps/vetrina-staging/.build-size-sha256
+++ b/apps/vetrina-staging/.build-size-sha256
@@ -1,3 +1,3 @@
 # SHA256 of the content of the build directory.
 # This is used for triggering project deployment when there are updated dependecies.
-2906a60e19b8fe46ad93e22bd016314cd1572c8902993eb8c206a2dcda6fe6c1
+b630e113664b6c50b16ea19a985659f8eba98eaba63c9e10f10285609a1fe149

--- a/less/Vetrina.less
+++ b/less/Vetrina.less
@@ -146,3 +146,8 @@
         width: 100%;
     }
 }
+
+.vetrina--temporary-user-email {
+    text-align: center;
+    margin-bottom: 1em;
+}

--- a/packages/vetrina/package.json
+++ b/packages/vetrina/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ksf-media/vetrina",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Vetrina, frontend for purchasing KSF Media products",
   "license": "MIT",
   "scripts": {

--- a/packages/vetrina/src/Vetrina/Purchase/NewPurchase.purs
+++ b/packages/vetrina/src/Vetrina/Purchase/NewPurchase.purs
@@ -5,9 +5,9 @@ import Prelude
 import Control.Alt ((<|>))
 import Data.Array (all, cons, intercalate)
 import Data.Array as Array
-import Data.Foldable (foldMap)
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Foldable (foldMap)
+import Data.Maybe (Maybe(..), fromMaybe, isNothing)
 import Data.Nullable (toMaybe)
 import Data.Validation.Semigroup (toEither, unV)
 import Effect (Effect)
@@ -123,6 +123,14 @@ didMount self = do
 render :: Self -> JSX
 render self =
   DOM.h1_ [ title self.state.accountStatus ]
+  <> case self.state.accountStatus of
+    LoggedInAccount user
+      | isNothing $ toMaybe user.firstName ->
+        DOM.div
+          { className: "vetrina--temporary-user-email"
+          , children: [ DOM.text user.email ]
+          }
+    _ -> mempty
   <> DOM.p
        { className: "vetrina--description-text"
        , children: [ description self.state.accountStatus ]


### PR DESCRIPTION
When the user is logged in but has no firstname defined, the landing page of vetrina might be a bit confusing. So let's show their email address there.