### PR TITLE
In text ad refactoring

### DIFF
--- a/apps/app-article/src/App.js
+++ b/apps/app-article/src/App.js
@@ -64,9 +64,6 @@ class App extends Component {
         };
     }
     componentDidMount() {
-        if (window.ksfDfp) {
-            window.addEventListener('load', window.ksfDfp.startUp);
-        }
         if (localStorage.getItem("currentUser") !== null) {
             this.setState({user: JSON.parse(localStorage.getItem("currentUser"))});
         }
@@ -94,7 +91,6 @@ class App extends Component {
     componentDidUpdate(){
         } 
 componentWillUnmount() {
-   window.removeEventListener('load', window.ksfDfp.startUp);
 }  
     onLogout() {
         console.log("Logged out successfully!");
@@ -377,36 +373,84 @@ componentWillUnmount() {
         window.dataLayer.push(push_data);
     }
 
+    /* The purpose of this function is to place ad slots in page text. It will try to space them out avoiding images, news graphics, iframes etc. 
+    It will not place slots in articles with less than 4 paragraphs. If no good paragraphs are found, the slots are placed after the text. It will allow <b>, <a href> and <i> within paragraphs. Other tags will disqualify that paragraph. Note that this function will call the main ads script on completion. This should prevent timing issues, no ads are loaded till all paragraphs are rolled out and inspected.
+    The script depends on the article text residing in an element with the id 'content'. */
     positionAdsWithinArticle() {
-        let countImages = 0;
-        let countOtherElements = 0;
-        let elementsInOrder = [];
+        let textParagrapNum = 0; // incremental number of text paragraphs
+        let textParagraphsOK = []; // storage for list of good paragraphs. We will use this array to find good spots for our slots.
+        let textParagraphCount = 0; // count of paragraph array groups
+        let slotOne = '<div id="DIGIHELMOB"></div>';
+        let slotTwo = '<div id="MOBMITT"></div>';
+        textParagraphsOK.push([]);
 
-        if (document.getElementById('content') != null) {
-            document.getElementById('content').childNodes.forEach(node => {
-                if (node.className === 'image') {
-                    countImages++;
-                    elementsInOrder.push('image');
-                } else {
-                    countOtherElements++;
-                    elementsInOrder.push('other');
-                }
-            });
+        var contentDiv = document.getElementById('content');
+        if (contentDiv != null) {
+            contentDiv.childNodes.forEach(node => {
 
-            if (countImages === 0) {
-                let middle = Math.ceil(elementsInOrder.length / 2);
-                let ad = document.createElement('div');
-                ad.setAttribute("id", "MOBMITT");
-                document.getElementById('content').childNodes[middle].appendChild(ad);
-            } else {
-                let ad = document.createElement('div');
-                ad.setAttribute("id", "MOBMITT");
-                if (document.getElementById('content').hasChildNodes()) {
-                    document.getElementById('content').childNodes[elementsInOrder.length - 1].appendChild(ad);
-                }
-            }
-        }
+                    if (node.className === 'html') {
+                        var OK = true;
+                        let approvedTags = ['B', 'A', 'I'];
+                        let t = node.getElementsByTagName("*");
+                        // check for non-text content
+                        if (t.length > 0) {
+                            for (let item of t) {
+                                let upperCased = item.nodeName;
+                                upperCased = upperCased.toUpperCase();
+
+                                if (approvedTags.indexOf(upperCased) > -1) {} else {
+                                    OK = false;
+                                }
+                            }
+                        }
+                                        textParagrapNum++;
+                                        if (OK && textParagrapNum > 3) {
+                                            // We are far enough from the beginning and the previous para was text, as is this and text is long enough. Good! We approve the paragraph for ads 
+                                            textParagraphsOK[textParagraphCount].push(textParagrapNum);
+                                        } else {
+                                            textParagraphCount++;
+                                            textParagraphsOK.push([]);
+                                        }
+                                        } else {
+                                            textParagraphCount++;
+                                            textParagraphsOK.push([]);
+                                        }
+                                        });
+
+                                        }
+textParagraphsOK = textParagraphsOK.filter(set => set.length > 0);
+var digiHelPick = 0;
+var digiHelGood = false;
+var mobMittPick = 0;
+var mobMittGood = false;
+var AllParas = contentDiv.getElementsByClassName('html');
+if (AllParas && textParagraphsOK.length > 0) {
+    digiHelPick = textParagraphsOK[0][0];
+    if (digiHelPick > 3) {
+        digiHelGood = true;
+        AllParas[digiHelPick - 1].insertAdjacentHTML('beforebegin', slotOne);
     }
+    let mMittSet = Math.ceil(textParagraphsOK.length / 2);
+    if (mMittSet > 1 || textParagraphsOK[mMittSet - 1].length > 5) {
+        mobMittPick = textParagraphsOK[mMittSet - 1][Math.floor(textParagraphsOK[mMittSet - 1].length / 2)];
+        mobMittGood = true;
+        AllParas[mobMittPick - 1].insertAdjacentHTML('beforebegin', slotTwo);
+    }
+    // Place slots after text in case we could not place them in text.
+    if (!digiHelGood) {
+        let endPlace = AllParas.length - 1;
+        AllParas[endPlace].insertAdjacentHTML('afterend', slotOne);
+    }
+    if (!mobMittGood) {
+        let endPlace = AllParas.length - 1;
+        AllParas[endPlace].insertAdjacentHTML('afterend', slotTwo);
+    }
+}
+
+if (window.ksfDfp) {
+    window.ksfDfp.startUp();
+}
+}
 
     onRegisterOpen() {
         // alert("register opn .");
@@ -574,7 +618,6 @@ componentWillUnmount() {
                 </div>
                 {/*<div id="MOBMITT"></div>*/}
 
-                <div id="DIGIHELMOB"></div>
                 <Footer/>
             </div>
         );

--- a/apps/app-article/src/App.js
+++ b/apps/app-article/src/App.js
@@ -377,7 +377,7 @@ componentWillUnmount() {
     It will not place slots in articles with less than 4 paragraphs. If no good paragraphs are found, the slots are placed after the text. It will allow <b>, <a href> and <i> within paragraphs. Other tags will disqualify that paragraph. Note that this function will call the main ads script on completion. This should prevent timing issues, no ads are loaded till all paragraphs are rolled out and inspected.
     The script depends on the article text residing in an element with the id 'content'. */
     positionAdsWithinArticle() {
-        let textParagrapNum = 0; // incremental number of text paragraphs
+        let textParagraphNum = 0; // incremental number of text paragraphs
         let textParagraphsOK = []; // storage for list of good paragraphs. We will use this array to find good spots for our slots.
         let textParagraphCount = 0; // count of paragraph array groups
         let slotOne = '<div id="DIGIHELMOB"></div>';
@@ -403,10 +403,10 @@ componentWillUnmount() {
                                 }
                             }
                         }
-                                        textParagrapNum++;
-                                        if (OK && textParagrapNum > 3) {
+                                        textParagraphNum++;
+                                        if (OK && textParagraphNum > 3) {
                                             // We are far enough from the beginning and the previous para was text, as is this and text is long enough. Good! We approve the paragraph for ads 
-                                            textParagraphsOK[textParagraphCount].push(textParagrapNum);
+                                            textParagraphsOK[textParagraphCount].push(textParagraphNum);
                                         } else {
                                             textParagraphCount++;
                                             textParagraphsOK.push([]);

--- a/apps/app-article/src/index.css
+++ b/apps/app-article/src/index.css
@@ -185,32 +185,13 @@ body {
 }
 
 /*Ads*/
-#MOBPARAD {
+#MOBPARAD, #MOBMITT, #MOBNER, #DIGIHELMOB {
     text-align: center;
     margin-bottom: 20px;
     overflow: hidden;
     max-width: 100%;
-}
-
-#MOBMITT {
-    text-align: center;
-    margin-bottom: 20px;
-    overflow: hidden;
-    max-width: 100%;
-}
-
-#MOBNER {
-    text-align: center;
-    margin-bottom: 20px;
-    overflow: hidden;
-    max-width: 100%;
-}
-
-#DIGIHELMOB {
-    text-align: center;
-    margin-bottom: 20px;
-    overflow: hidden;
-    max-width: 100%;
+    display: grid;
+    justify-content: center;
 }
 
 .ksfDFPadHeader {

--- a/scripts/app/gamAppAds.js
+++ b/scripts/app/gamAppAds.js
@@ -64,6 +64,7 @@ var ksfDfp = {};
         // this var is available in KSF sites
         ksfDfp.site = "app"; // there is only one site in the app
         googletag.pubads().setTargeting('newspaper', ksfDfp.site);
+        googletag.pubads().setTargeting('consent', 1);
 
         ksfDfp.allPageSlots = [];
         // the order of sizes should be the same as in dfp:s ad unit definition

--- a/scripts/app/gamAppAds.js
+++ b/scripts/app/gamAppAds.js
@@ -1,92 +1,14 @@
 var googletag = googletag || {};
 var ksfDfp = {};
-ksfDfp.mover = {}; // holds vars and functions needed for the ad mover functions
 
 (function() {
     'use strict';
     googletag.cmd = googletag.cmd || [];
 
     ksfDfp.displayBanner = function(id) {
-        // run display function but first check that the slot is supposed to render. This avoids DFP silent errors  and might improve performance. Placed here because this function needs to exits even if the onSwitch is in off position.
         googletag.cmd.push(function() {
             googletag.display(id);
         });
-    };
-    ksfDfp.mover.checkPara = function(ptag, expectedType, expectedClass) {
-        // used by the bannerMover function
-        var response = false;
-        expectedType = expectedType.toUpperCase(); // nodeName is always uppercase
-        // check that the surrounding paragraphs are OK when placing the in text ad
-        var pBefore = ptag.previousElementSibling;
-        var pBeforeContent = pBefore.innerHTML.replace(/[^A-Za-z0-9]/g, '');
-        var pBeforeClass = pBefore.classList.contains(expectedClass);
-        var pSelf = ptag;
-        var pSelfContent = pSelf.innerHTML.replace(/[^A-Za-z0-9]/g, '');
-        var pSelfClass = pSelf.classList.contains(expectedClass);
-        if ((!(/^\s*$/.test(pBeforeContent)) && !(/^\s*$/.test(pSelfContent))) && (pSelf.nodeName === expectedType && pBefore.nodeName === expectedType) && (pBeforeClass && pSelfClass)) {
-            response = true;
-        }
-        return response;
-    };
-    /*
-    Set up mover function. Find ad slot for DIGIHELMOB and move it into the middle of the text,
-        if available.
-    */
-    // this must be true. Setting it to false is the way to chicken out
-    ksfDfp.mover.letTheBoxMove = true;
-    // reduce risk of banner collisions and other placement oddities
-    ksfDfp.mover.paragraphType = 'div'; // the type of HTML element used for paragraphs
-    ksfDfp.mover.paragraphClass = 'html'; // the name of the css class of egible paragraphs
-    ksfDfp.mover.articleContainerName = 'App'; // the class of the main article container. Could make sense to have this as id. But it is a class in the documents.
-    ksfDfp.mover.articleTextContainerName = 'content'; // this is an id
-    ksfDfp.mover.minimumTextLength = 7; // text with less paragraphs are not touched
-    ksfDfp.mover.adDivToMove = "DIGIHELMOB"; // name of the div that we should move up
-    ksfDfp.mover.done = false;
-    ksfDfp.mover.report = 'OK';
-    ksfDfp.bannerMover = function() {
-        let textDivTop = window.document.getElementsByClassName(ksfDfp.mover.articleContainerName);
-        if (!(textDivTop[0] === undefined)) {
-            let textDiv = document.getElementById(ksfDfp.mover.articleTextContainerName);
-
-            // count the number of paragraphs
-            let paras = textDivTop[0].querySelectorAll(ksfDfp.mover.paragraphType + '.' + ksfDfp.mover.paragraphClass);
-            let parasNum = paras.length;
-            if (parasNum < ksfDfp.mover.minimumTextLength) {
-                ksfDfp.mover.report = 'Short text ' + parasNum;
-                // not worth moving ads in very short texts
-                ksfDfp.mover.letTheBoxMove = false;
-            }
-            let placementPositionNum = Math.floor(parasNum / 2);
-            let placementElement = paras[placementPositionNum];
-            if (placementElement && ksfDfp.mover.letTheBoxMove) {
-                // verify that the new placement is OK. This requires the new placement to be surrounded by non-empty text tags.
-                let isParaOK = ksfDfp.mover.checkPara(placementElement, ksfDfp.mover.paragraphType, ksfDfp.mover.paragraphClass); // element + expected type and class name
-                if (!isParaOK) {
-                    ksfDfp.mover.report = 'First attempt failed ' + placementPositionNum;
-                    //last ditch attempt or give up
-                    placementElement = paras[placementPositionNum - 2];
-                    isParaOK = ksfDfp.mover.checkPara(placementElement, ksfDfp.mover.paragraphType, ksfDfp.mover.paragraphClass);
-                    // if still not OK, we chicken out
-                    if (!isParaOK) {
-                        ksfDfp.mover.letTheBoxMove = false;
-                        ksfDfp.mover.report = 'Both attempts failed ' + placementPositionNum;
-                    }
-                }
-                let adDivToMoveElement = window.document.getElementById(ksfDfp.mover.adDivToMove);
-                if (adDivToMoveElement !== null) {
-                    if (ksfDfp.mover.letTheBoxMove) {
-                        textDiv.insertBefore(adDivToMoveElement, placementElement);
-                        ksfDfp.mover.done = true; // don't run this more than once
-                    }
-                } else {
-                    ksfDfp.mover.report = 'Could not find specified div to move';
-                }
-            }
-            // found the necessary text containers
-        } else {
-            ksfDfp.mover.report = 'Failed to find top container';
-        }
-
     };
 
     ksfDfp.getBannerWidth = function(banner) {
@@ -112,11 +34,6 @@ ksfDfp.mover = {}; // holds vars and functions needed for the ad mover functions
         ksfDfp.startUp = function() {
             if (!ksfDfp.activated) {
                 ksfDfp.activated = true;
-                // move slots that are to be repositioned in the document
-                if (!ksfDfp.mover.done) {
-                    // timeout is really ugly but the react onload in componentdidmount is not reliable. This is even recommended by some. Without it long articles will fail. With it some short articles fail. 
-                    window.setTimeout(ksfDfp.bannerMover, 200);
-                }
                 // activate display for all slots
                 var n = ksfDfp.numberOfSlots - 1;
                 var slotId = [];
@@ -146,6 +63,7 @@ ksfDfp.mover = {}; // holds vars and functions needed for the ad mover functions
 
         // this var is available in KSF sites
         ksfDfp.site = "app"; // there is only one site in the app
+        googletag.pubads().setTargeting('newspaper', ksfDfp.site);
 
         ksfDfp.allPageSlots = [];
         // the order of sizes should be the same as in dfp:s ad unit definition
@@ -158,6 +76,14 @@ ksfDfp.mover = {}; // holds vars and functions needed for the ad mover functions
                     [300, 300],
                     [300, 600]
                 ]],
+            ["MOBMITT", [
+
+                    [300, 100],
+                    [300, 250],
+                    [300, 300],
+                    [300, 600]
+                ]],
+
             ["MOBNER", [
                     [300, 100],
                     [300, 250],
@@ -202,9 +128,6 @@ ksfDfp.mover = {}; // holds vars and functions needed for the ad mover functions
                     ksfDfp.slotObjects[ksfDfp.slots[n][0]] = googletag.defineSlot(ksfDfp.account +
                         ksfDfp.slots[n][0], bannerSizeList, ksfDfp.slots[n][0]).addService(
                         googletag.pubads());
-                    // add a targeting value that differentiates the site. key=newpaper, value is site from the ksf wordpress code base. Such as vn, hbl etc.
-                    ksfDfp.slotObjects[ksfDfp.slots[n][0]].setTargeting("newspaper", [ksfDfp.site]);
-                    ksfDfp.slotObjects[ksfDfp.slots[n][0]].setTargeting("consent", 1); // this sets consent to not accept tracking ads, for use in campaigns trafficed by us. This is hardcoded for now due to policy. 20191029
                 } // slot size to screen comparison end of if
                 n -= 1;
             }


### PR DESCRIPTION
Some major changes to how in text ads are handled. Some code in App.js was removed and replaced with a function that checks paragraphs to see if they are appropriate for ad placement. There are two ad slots placed, DIGIHELMOB and MOBMITT. The MOBMITT was mostly failing to get placed with the old code. The code placing DIGIHELMOB was previously in the external ads script and suffered from some timing issues. The placement code is now removed from the external script and that script is now run after the slots have been placed, from App.js.
Note that both the App.js and the external ad script must be updated for this to work, so caching issues might cause problems.