### PR TITLE
Fix/persona api

### DIFF
--- a/apps/mitt-konto/.build-size-sha256
+++ b/apps/mitt-konto/.build-size-sha256
@@ -1,3 +1,3 @@
 # SHA256 of the content of the build directory.
 # This is used for triggering project deployment when there are updated dependecies.
-8229f3358679d0e1aaf8248b3c90e2f1c5b142388e0e53a1fe34d363a61dbaaf
+c3a174d57538aef49ebd5fdbd25331452e0f0850a282b2b0624565f10b62ebf8

--- a/packages/components/src/Persona.purs
+++ b/packages/components/src/Persona.purs
@@ -58,14 +58,14 @@ getUserEntitlements uuid token =
   callApi usersApi "usersUuidEntitlementGet" [ unsafeToForeign uuid ] { authorization: oauthToken token }
 
 updateUser :: UUID -> UserUpdate -> Token -> Aff User
-updateUser uuid update token =
-  let
-    authorization = oauthToken token
-    body = case update of
-      UpdateName names      -> unsafeToForeign names
-      UpdateAddress address -> unsafeToForeign { address }
-  in
-   callApi usersApi "usersUuidPatch" [ unsafeToForeign uuid, body ] { authorization }
+updateUser uuid update token = do
+  let authorization = oauthToken token
+      body = case update of
+        UpdateName names      -> unsafeToForeign names
+        UpdateAddress address -> unsafeToForeign { address }
+  user <- callApi usersApi "usersUuidPatch" [ unsafeToForeign uuid, body ] { authorization }
+  let parsedSubs = map Subscription.parseSubscription user.subs
+  pure $ user { subs = parsedSubs }
 
 updateGdprConsent :: UUID -> Token -> Array GdprConsent -> Aff Unit
 updateGdprConsent uuid token consentValues = callApi usersApi "usersUuidGdprPut" [ unsafeToForeign uuid, unsafeToForeign consentValues ] { authorization }


### PR DESCRIPTION
So due to the adding of the `paymentMethod` field to a `Subscription`record, `getUser` from our `Persona` component parses the content of that field into an instance of the `PaymentMethod` type.

This has to happen for the `updateUser` method too, otherwise all the pieces of code that use the `paymentMethod` field of a `User` record obtained with it will throw an error, like e.g. updating user's name/surname.