### PR TITLE
Add subscriber mostread for HBL in app article

### DIFF
--- a/apps/app-article/src/article-service.js
+++ b/apps/app-article/src/article-service.js
@@ -17,7 +17,9 @@ const articleApi = {
             .then(response => response.json())
     },
     getMostReadArticles() {
-        return fetch(config.apiUrl + "mostread?start=0&limit=10&paper=" + getBrandValueParam(), {
+        const brand = getBrandValueParam();
+        //We only want exclusively subscriber data for hbl, others can have all data
+        return fetch(`${config.apiUrl}mostread?start=0&limit=10&paper=${brand}&onlySubscribers=${brand==='hbl'}`, {
             method: 'GET',
         })
             .then(response => response.json())


### PR DESCRIPTION
We want to exclusively show subscriber data for the most read list in the app article in HBL Nyheter. The other news apps can use all most read data.