### PR TITLE
Better bottega errors

### DIFF
--- a/apps/mitt-konto/src/MittKonto/AccountEdit.purs
+++ b/apps/mitt-konto/src/MittKonto/AccountEdit.purs
@@ -2,6 +2,7 @@ module MittKonto.AccountEdit where
 
 import Prelude
 
+import Bottega (bottegaErrorMessage)
 import Bottega.Models (CreditCard)
 import Data.Array (null)
 import Data.Either (Either(..))
@@ -58,7 +59,7 @@ didMount self =
     Aff.launchAff_ do
       creditCards <- User.getCreditCards
       case creditCards of
-        Left err    -> liftEffect $ self.props.logger.log ("Error while fetching credit cards: " <> err) Sentry.Error
+        Left err    -> liftEffect $ self.props.logger.log ("Error while fetching credit cards: " <> bottegaErrorMessage err) Sentry.Error
         Right []    -> pure unit
         Right cards -> liftEffect do
           self.props.setCreditCards cards

--- a/packages/components/src/Api/Error.purs
+++ b/packages/components/src/Api/Error.purs
@@ -1,0 +1,30 @@
+module KSF.Api.Error where
+
+import Prelude
+
+import Control.Monad.Except (runExcept)
+import Data.Either (hush)
+import Data.Maybe (Maybe)
+import Effect.Exception (Error)
+import Foreign (unsafeToForeign)
+import Foreign.Index as Foreign
+import Simple.JSON (class ReadForeign)
+import Simple.JSON as JSON
+
+type ServerError extraFields =
+  { http_status :: String
+  , http_code :: Int
+  | extraFields
+  }
+
+errorData
+  :: forall fields
+   . ReadForeign (ServerError fields)
+  => Error
+  -> Maybe (ServerError fields)
+errorData =
+  hush
+    <<< (JSON.read =<< _)
+    <<< runExcept
+          <<< Foreign.readProp "data"
+          <<< unsafeToForeign

--- a/packages/components/src/Bottega.purs
+++ b/packages/components/src/Bottega.purs
@@ -3,11 +3,14 @@ module Bottega where
 import Prelude
 
 import Bottega.Models (CreditCard, CreditCardId, CreditCardRegister, CreditCardRegisterNumber, NewOrder, Order, OrderNumber, PaymentMethod, PaymentMethodId, PaymentTerminalUrl, parseCreditCardRegisterState, parseOrderState)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Nullable (Nullable, toMaybe, toNullable)
 import Data.Traversable (traverse)
 import Effect.Aff (Aff)
 import Foreign (unsafeToForeign)
 import KSF.Api (UUID, UserAuth, oauthToken)
+import KSF.Api.Error (ServerError)
 import KSF.Api.Package (Package)
 import OpenApiClient (Api, callApi)
 
@@ -24,7 +27,7 @@ type ApiOrder =
 type ApiOrderStatus =
   { state :: String
   , time :: String
-  , failReason :: Nullable String 
+  , failReason :: Nullable String
   }
 
 type ApiCreditCard =
@@ -32,7 +35,7 @@ type ApiCreditCard =
   , user :: UUID
   , paymentMethodId :: PaymentMethodId
   , maskedPan :: String
-  , expiryDate :: String 
+  , expiryDate :: String
   }
 
 type ApiCreditCardRegister =
@@ -40,15 +43,32 @@ type ApiCreditCardRegister =
    , user :: UUID
    , creditCardId :: CreditCardId
    , paymentTerminalUrl :: Nullable PaymentTerminalUrl
-   , status :: ApiCreditCardRegisterStatus 
+   , status :: ApiCreditCardRegisterStatus
    }
 
 type ApiCreditCardRegisterStatus =
   { state :: String
   , time :: String
-  , failReason :: Nullable String 
+  , failReason :: Nullable String
   }
 
+type InsufficientAccount = ServerError
+  ( missing_address_details ::
+    { message :: String }
+  )
+
+-- TODO: Add more errors!
+data BottegaError
+  = BottegaInsufficientAccount -- ^ Cannot create order due to missing account data
+  | BottegaUnexpectedError String
+
+derive instance genericBottegaError :: Generic BottegaError _
+instance showBottegaError :: Show BottegaError where
+  show = genericShow
+
+bottegaErrorMessage :: BottegaError -> String
+bottegaErrorMessage (BottegaUnexpectedError errMsg) = errMsg
+bottegaErrorMessage e = show e
 
 createOrder :: UserAuth -> NewOrder -> Aff Order
 createOrder { userId, authToken } newOrder@{ campaignNo } =
@@ -83,7 +103,7 @@ getPackages :: Aff (Array Package)
 getPackages = callApi packagesApi "packageGet" [] {}
 
 readCreditCard :: ApiCreditCard -> Aff CreditCard
-readCreditCard creditCardObj = pure $ 
+readCreditCard creditCardObj = pure $
   { id: creditCardObj.id, user: creditCardObj.user, paymentMethodId: creditCardObj.paymentMethodId, maskedPan: creditCardObj.maskedPan, expiryDate: creditCardObj.expiryDate }
 
 readCreditCardRegister :: ApiCreditCardRegister -> Aff CreditCardRegister
@@ -127,7 +147,7 @@ getCreditCardRegister { userId, authToken } creditCardId creditCardRegisterNumbe
     authUser = unsafeToForeign userId
 
 updateCreditCardSubscriptions :: UserAuth -> CreditCardId -> CreditCardId -> Aff Unit
-updateCreditCardSubscriptions { userId, authToken } oldCreditCardId newCreditCardId = 
+updateCreditCardSubscriptions { userId, authToken } oldCreditCardId newCreditCardId =
   callApi paymentMethodsApi "paymentMethodCreditCardIdSubscriptionPut" [ unsafeToForeign oldCreditCardId, unsafeToForeign newCreditCardId ] { authorization, authUser }
   where
     authorization = oauthToken authToken


### PR DESCRIPTION
Instead of returning just a `String` every time we encounter an error from Bottega, add a proper type for that. This PR adds one constructor to that type 😅 However, we should add constructors to this when/if needed.

The main purpose here is to catch the `missing_address_details` error, so we can show the address form in Vetrina.