### PR TITLE
Bump easy-dhall-nix hash

### DIFF
--- a/ci/dhall.nix
+++ b/ci/dhall.nix
@@ -5,8 +5,8 @@ let
     pkgs.fetchFromGitHub {
       owner = "justinwoo";
       repo = "easy-dhall-nix";
-      rev = "90957969850a44481c6e150350c56e8b53b29e1e";
-      sha256 = "1hsmp3cb0k554kh0jlfzpdzx2b8ndyh2gdykmw9hw41haaw16mmi";
+      rev = "eae7f64c4d6c70681e5a56c84198236930ba425e";
+      sha256 = "pzcwv9qLuk4qkxw5YOD95krF3YpXftUv3ekYhXYJXfg=";
     }
   ) {
     inherit pkgs;


### PR DESCRIPTION
This should be enough to prevent building its dependencies from scratch each time.