### PR TITLE
Allow disabling pauses and temp address changes for some package types

### DIFF
--- a/apps/mitt-konto/src/MittKonto/Main/Views/UserView/Subscription/Elements.purs
+++ b/apps/mitt-konto/src/MittKonto/Main/Views/UserView/Subscription/Elements.purs
@@ -14,7 +14,7 @@ import Data.String (trim)
 import Data.Tuple (Tuple(..))
 import Effect.Aff as Aff
 import Effect.Class (liftEffect)
-import KSF.Api.Subscription (SubscriptionPaymentMethod(..))
+import KSF.Api.Subscription (SubscriptionPaymentMethod(..), isSubscriptionPausable, isSubscriptionTemporaryAddressChangable)
 import KSF.AsyncWrapper as AsyncWrapper
 import KSF.DeliveryReclamation as DeliveryReclamation
 import KSF.DescriptionList.Component as DescriptionList
@@ -128,11 +128,11 @@ subscriptionUpdates self@{ props: props@{ subscription: sub@{ subsno, package } 
       }
 
     paperOnlyActions =
-      [ pauseIcon
+      [ if isSubscriptionPausable sub then pauseIcon else mempty
       , if maybe true Array.null self.state.pausedSubscriptions
           then mempty
           else removeSubscriptionPauses
-      , temporaryAddressChangeIcon
+      , if isSubscriptionTemporaryAddressChangable sub then temporaryAddressChangeIcon else mempty
       , case self.state.pendingAddressChanges of
               Just a -> removeTempAddressChanges a
               Nothing -> mempty

--- a/packages/components/src/Api/Package.purs
+++ b/packages/components/src/Api/Package.purs
@@ -17,6 +17,8 @@ type Package =
   , nextDelivery :: Nullable JSDate
   , description  :: Nullable PackageDescription
   , digitalOnly  :: Boolean
+  , canPause     :: Boolean
+  , canTempAddr  :: Boolean
   }
 
 type PackageDescription =

--- a/packages/components/src/Api/Subscription.purs
+++ b/packages/components/src/Api/Subscription.purs
@@ -1,6 +1,6 @@
 module KSF.Api.Subscription where
 
-import Prelude (class Eq, class Ord, comparing, map, pure)
+import Prelude
 
 import Control.Alt ((<|>))
 import Data.Either (Either(..))
@@ -100,3 +100,9 @@ isSubscriptionCanceled s = isSubscriptionStateCanceled s.state
 isSubscriptionStateCanceled :: SubscriptionState -> Boolean
 isSubscriptionStateCanceled (SubscriptionState "Canceled") = true
 isSubscriptionStateCanceled _ = false
+
+isSubscriptionPausable :: Subscription -> Boolean
+isSubscriptionPausable = _.canPause <<< _.package
+
+isSubscriptionTemporaryAddressChangable :: Subscription -> Boolean
+isSubscriptionTemporaryAddressChangable = _.canTempAddr <<< _.package

--- a/packages/user/package.json
+++ b/packages/user/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "basscss": "^8.1.0",
-    "persona": "https://github.com/KSF-Media/persona-javascript-client.git#377029ceeec19e9489a7d67c88d86808b9ea6edf",
+    "persona": "https://github.com/KSF-Media/persona-javascript-client.git#afaca2973b6b0aa7485fec85944cd60cc14876a0",
     "bottega": "https://github.com/KSF-Media/bottega-javascript-client.git#9172de9399aaf8fbe10b1ceae2a3b8a5d77a8456",
     "react": "^16.12",
     "react-dom": "^16.12"

--- a/packages/vetrina/package.json
+++ b/packages/vetrina/package.json
@@ -11,7 +11,7 @@
     "@sentry/browser": "^6.2.1",
     "bottega": "https://github.com/KSF-Media/bottega-javascript-client.git#97c364fb00908818d02b54a8fe418cccdeaffc48",
     "create-react-class": "^15.6.3",
-    "persona": "https://github.com/KSF-Media/persona-javascript-client.git#377029ceeec19e9489a7d67c88d86808b9ea6edf",
+    "persona": "https://github.com/KSF-Media/persona-javascript-client.git#afaca2973b6b0aa7485fec85944cd60cc14876a0",
     "purescript": "^0.13.8",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,7 +1411,7 @@
   dependencies:
     basscss "^8.1.0"
     bottega "https://github.com/KSF-Media/bottega-javascript-client.git#9172de9399aaf8fbe10b1ceae2a3b8a5d77a8456"
-    persona "https://github.com/KSF-Media/persona-javascript-client.git#377029ceeec19e9489a7d67c88d86808b9ea6edf"
+    persona "https://github.com/KSF-Media/persona-javascript-client.git#afaca2973b6b0aa7485fec85944cd60cc14876a0"
     react "^16.12"
     react-dom "^16.12"
 
@@ -7359,15 +7359,15 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"persona@https://github.com/KSF-Media/persona-javascript-client.git#377029ceeec19e9489a7d67c88d86808b9ea6edf":
-  version "1.3.0"
-  resolved "https://github.com/KSF-Media/persona-javascript-client.git#377029ceeec19e9489a7d67c88d86808b9ea6edf"
-  dependencies:
-    superagent "3.7.0"
-
 "persona@https://github.com/KSF-Media/persona-javascript-client.git#72a5ee779d5a9052b3cd274db9d":
   version "1.3.0"
   resolved "https://github.com/KSF-Media/persona-javascript-client.git#72a5ee779d5a9052b3cd274db9d5358ddd27839b"
+  dependencies:
+    superagent "3.7.0"
+
+"persona@https://github.com/KSF-Media/persona-javascript-client.git#afaca2973b6b0aa7485fec85944cd60cc14876a0":
+  version "1.3.0"
+  resolved "https://github.com/KSF-Media/persona-javascript-client.git#afaca2973b6b0aa7485fec85944cd60cc14876a0"
   dependencies:
     superagent "3.7.0"
 


### PR DESCRIPTION
This adds `canPause` and `canTempAddr` fields to packages data.

Reminder: Don't merge to master before deploying Persona with those fields to production.

This'll be followed by another change to actually set these fields for the affected products, but that'll be on back end.