### PR TITLE
Remove magic login attempt from Login component

### DIFF
--- a/apps/mitt-konto/src/MittKonto/Main/Views/LoginView.purs
+++ b/apps/mitt-konto/src/MittKonto/Main/Views/LoginView.purs
@@ -55,7 +55,7 @@ loginView self@{ state, setState } logger =
                 admin <- isAdminUser
                 setState $ (Types.setActiveUser $ Just user) <<< (_ { adminMode = admin } )
                 logger.setUser $ Just user
-          , launchAff_:
+          , onLogin:
               Aff.runAff_ (setState <<< Types.setAlert <<< either Helpers.errorAlert (const Nothing))
                 <<< Spinner.withSpinner (setState <<< Types.setLoading)
           , disableSocialLogins: Set.empty

--- a/apps/mosaico/src/Mosaico/LoginModal.purs
+++ b/apps/mosaico/src/Mosaico/LoginModal.purs
@@ -76,7 +76,7 @@ render props state =
                     , onRegister: pure unit
                     , onRegisterCancelled: pure unit
                     , onUserFetch: props.onUserFetch
-                    , launchAff_: \aff -> do
+                    , onLogin: \aff -> do
                         Console.log "LAUNCHING AFF"
                         -- TODO: spinners and things
                         Aff.launchAff_ aff


### PR DESCRIPTION
Let's move the magic login responsibility (the automatic logging in if uuid + token are found in local storage) to the client of Login component rather than have it in the Login itself.
Because if you think about it, if we already have the user, it makes no sense to mount the Login component in the first place. 

Also rename the `launchAff_` prop of Login to `onLogin`.