### PR TITLE
Simulate click to directly view as customer

### DIFF
--- a/packages/components/src/Search.purs
+++ b/packages/components/src/Search.purs
@@ -44,6 +44,7 @@ import React.Basic.Events as Events
 
 type Props =
   { setActiveUser :: UUID -> Effect Unit
+  , resetRedirect :: Effect Unit
   , now           :: Date
   }
 
@@ -62,7 +63,7 @@ type TaggedSubscription =
 
 search :: Component Props
 search = do
-  component "Search" \ { setActiveUser, now } -> React.do
+  component "Search" \ { setActiveUser, resetRedirect, now } -> React.do
     query /\ setQuery <- useState' Nothing
     results /\ setTaggedResults <- useState Nothing
     (searchWrapper :: AsyncWrapper.Progress JSX) /\ setSearchWrapper <- useState' AsyncWrapper.Ready
@@ -73,6 +74,7 @@ search = do
           _ /\ Just uuid -> setActiveUser uuid
           Just q /\ _ -> do
             setSearchWrapper $ AsyncWrapper.Loading mempty
+            resetRedirect
             Aff.launchAff_ do
               queryResult <- User.searchUsers { query: q, faroLimit: 10 }
               case queryResult of


### PR DESCRIPTION
This is disgusting and I wouldn't be doing it this way if this wasn't for internal use.

Just using `setHref` will reload the page and discard any personation. Pushing or replacing state with History API will change the address in the address bar but React will not react to that change. I don't think this could be done with any `Router.Link` on the button either since getting the user to personate is an `Aff` and not an `Effect`.

If you have an better idea about how to do this then I'm open to it.