### PR TITLE
Add onscroll handler for adding header.tight in HBL365

### DIFF
--- a/apps/hbl365/src/Main.js
+++ b/apps/hbl365/src/Main.js
@@ -4,3 +4,14 @@ exports.appStore = {
 };
 
 exports.logo = require('../../../../images/hbl365/app-icon-1024x1024-pixels.png');
+
+exports.addOnScroll = function() {
+    const header = document.getElementsByTagName('header')[0];
+    window.onscroll = function(ev) {
+	if (window.scrollY > 38) {
+	    header.classList.add('tight');
+	} else {
+	    header.classList.remove('tight');
+	}
+    }
+}

--- a/apps/hbl365/src/Main.purs
+++ b/apps/hbl365/src/Main.purs
@@ -6,6 +6,7 @@ import Data.Array as Array
 import Data.Either (Either)
 import Data.Maybe (Maybe(..))
 import Data.Set as Set
+import Effect (Effect)
 import Effect.Aff as Aff
 import Effect.Class (liftEffect)
 import Effect.Exception (Error)
@@ -28,6 +29,8 @@ foreign import appStore ::
 
 foreign import logo :: String
 
+foreign import addOnScroll :: Effect Unit
+
 jsApp :: {} -> JSX
 jsApp = unsafePerformEffect app
 
@@ -36,6 +39,7 @@ app = do
   component "HBL365" \_ -> React.do
     product /\ setProduct <- useState' Nothing
     useEffectOnce do
+      addOnScroll
       Aff.launchAff_ do
         liftEffect <<< setProduct <<< Just <<< map Array.singleton =<< getProduct
       pure $ pure unit

--- a/less/HBL365.less
+++ b/less/HBL365.less
@@ -95,6 +95,10 @@ header {
     }
 }
 
+header #logo-container img {
+    transition: transform 0.3s;
+}
+
 header.tight {
     height: 57px;
     box-shadow: 0px 0px 7px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
I couldn't think of a native PureScript way of doing this. The only onscroll handling code I saw was in Halogen and we don't use it.