### PR TITLE
Mosaico/grid

### DIFF
--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -175,16 +175,20 @@ render { props, state, setState } =
                               , foldMap articleTimestamps letteraArticle
                               ]
                           }
-                      , DOM.div
-                          { className: "mosaico--article--body "
-                          , children: case state.article of
-                            (Just (PreviewArticle _previewArticle)) ->
-                              paywallFade
-                              `cons` bodyWithAd
-                              `snoc` vetrina
-                            (Just (FullArticle _fullArticle)) ->
-                              bodyWithAd
-                            _ -> mempty
+                    , DOM.div
+                        { className: "mosaico--article--body "
+                        , children: case state.article of
+                          (Just (PreviewArticle _previewArticle)) ->
+                            paywallFade
+                            `cons` bodyWithAd
+                            `snoc` vetrina
+                          (Just (FullArticle _fullArticle)) ->
+                            bodyWithAd
+                          _ -> mempty
+                        }
+                    , DOM.div
+                        { className: "mosaico-article-aside"
+                        , children: []
                         }
                     ]
                 }

--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -141,8 +141,9 @@ render { props, state, setState } =
         mainImage = (_.mainImage =<< letteraArticle) <|> (_.listImage =<< props.articleStub)
         bodyWithAd = Ad.insertIntoBody adBox $ map renderElement state.body
     in DOM.div
-      { className: "mosaico--article"
+      { className: "article"
       , children:
+<<<<<<< Updated upstream
         [ DOM.div
             { className: "mosaico--tag color-" <> props.brand
             , children: [ DOM.text $ fromMaybe "" (head tags) ]
@@ -181,6 +182,56 @@ render { props, state, setState } =
               _ -> mempty
           }
       ]
+=======
+          [ DOM.header_
+            [ DOM.h1
+                { className: "mosaico--article--title title"
+                , children: [ DOM.text title ]
+                }
+            , DOM.div
+                { className: "mosaico--article--preamble"
+                , children: [ DOM.p_ [ DOM.text $ fromMaybe mempty state.preamble ] ]
+                }
+            ,  DOM.div
+                { className: "mosaico--tag color-" <> props.brand
+                , children: [ DOM.text $ fromMaybe "" (head tags) ]
+                }
+              , DOM.ul
+                  { className: "mosaico-article__some"
+                  , children: map mkShareIcon case state.article of
+                      Just (ErrorArticle _) -> []
+                      _                     -> [ "facebook", "twitter", "linkedin", "whatsapp", "mail" ]
+                  }
+            ]
+            , DOM.div
+                { className: "image"
+                , children: [ foldMap renderImage mainImage ]
+                }
+            , DOM.div 
+                { className: "articlebody"
+                , children:
+                    [ DOM.div
+                          { className: "mosaico--article-times-and-author"
+                          , children:
+                              [ foldMap renderAuthors $ _.authors <$> letteraArticle
+                              , foldMap articleTimestamps letteraArticle
+                              ]
+                          }
+                      , DOM.div
+                          { className: "mosaico--article--body "
+                          , children: case state.article of
+                            (Just (PreviewArticle _previewArticle)) ->
+                              paywallFade
+                              `cons` bodyWithAd
+                              `snoc` vetrina
+                            (Just (FullArticle _fullArticle)) ->
+                              bodyWithAd
+                            _ -> mempty
+                        }
+                    ]
+                }
+        ]
+>>>>>>> Stashed changes
     }
   where
     renderAuthors authors =

--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -156,12 +156,10 @@ render { props, state, setState } =
                 { className: "mosaico--tag color-" <> props.brand
                 , children: [ DOM.text $ fromMaybe "" (head tags) ]
                 }
-              , DOM.ul
-                  { className: "mosaico-article__some"
-                  , children: map mkShareIcon case state.article of
-                      Just (ErrorArticle _) -> []
-                      _                     -> [ "facebook", "twitter", "linkedin", "whatsapp", "mail" ]
-                  }
+            , DOM.ul
+                { className: "mosaico-article__some"
+                , children: map mkShareIcon [ "facebook", "twitter", "linkedin", "whatsapp", "mail" ]
+                }
             ]
             , DOM.div
                 { className: "image"

--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -143,46 +143,6 @@ render { props, state, setState } =
     in DOM.div
       { className: "article"
       , children:
-<<<<<<< Updated upstream
-        [ DOM.div
-            { className: "mosaico--tag color-" <> props.brand
-            , children: [ DOM.text $ fromMaybe "" (head tags) ]
-            }
-        , DOM.h1
-            { className: "mosaico--article--title title"
-            , children: [ DOM.text title ]
-            }
-        , foldMap renderImage mainImage
-        , DOM.div
-            { className: "mosaico--article--preamble"
-            , children: [ DOM.p_ [ DOM.text $ fromMaybe mempty state.preamble ] ]
-            }
-        , DOM.div
-            { className: "mosaico--article-times-and-author"
-            , children:
-                [ foldMap renderAuthors $ _.authors <$> letteraArticle
-                , foldMap articleTimestamps letteraArticle
-                ]
-            }
-        , DOM.ul
-            { className: "mosaico-article__some"
-            , children: map mkShareIcon case state.article of
-                Just (ErrorArticle _) -> []
-                _                     -> [ "facebook", "twitter", "linkedin", "whatsapp", "mail" ]
-            }
-        , DOM.div
-            { className: "mosaico--article--body "
-            , children: case state.article of
-              (Just (PreviewArticle _previewArticle)) ->
-                paywallFade
-                `cons` bodyWithAd
-                `snoc` vetrina
-              (Just (FullArticle _fullArticle)) ->
-                bodyWithAd
-              _ -> mempty
-          }
-      ]
-=======
           [ DOM.header_
             [ DOM.h1
                 { className: "mosaico--article--title title"
@@ -231,7 +191,6 @@ render { props, state, setState } =
                     ]
                 }
         ]
->>>>>>> Stashed changes
     }
   where
     renderAuthors authors =

--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -171,7 +171,9 @@ render setState state router =
         }
     _ -> mempty
   <> DOM.div
-       { className: "mosaico grid"
+       { className: case state.route of
+          ArticlePage _ -> "grid mosaico-article"
+          _             -> "grid mosaico-frontpage"  
        , children:
            [ Header.topLine
            , state.headerComponent { router: Just router }

--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -191,10 +191,13 @@ render setState state router =
                { className: "mosaico--footer"
                , children: [ DOM.text "footer" ]
                }
-           , DOM.aside
-              { className: "mosaico--aside"
-              , children: [ renderMostreadList state setState router ]
-              }
+           , case state.route of
+               Frontpage -> 
+                 DOM.aside
+                    { className: "mosaico--aside"
+                    , children: [ renderMostreadList state setState router ]
+                    }
+               _ -> mempty
            ]
        }
   where

--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -171,9 +171,7 @@ render setState state router =
         }
     _ -> mempty
   <> DOM.div
-       { className: case state.route of
-          ArticlePage _ -> "grid mosaico-article"
-          _             -> "grid mosaico-frontpage"  
+       { className: "mosaico grid"
        , children:
            [ Header.topLine
            , state.headerComponent { router: Just router }

--- a/less/mosaico/_grid.less
+++ b/less/mosaico/_grid.less
@@ -1,27 +1,5 @@
 .mosaico {
   display: grid;
-  grid-template-rows: auto 85px auto 1fr 150px;
-  grid-template-columns: 1fr;
-  grid-row-gap: 8px;
-  grid-template-areas:
-    "line"
-    "head"
-    "separator"
-    "main"
-    "foot";
-
-    @media (min-width: @breakpoint-3col) {
-      grid-template-areas:
-        "line line line"
-        ". head ."
-        "separator separator separator"
-        ". main ."
-        "foot foot foot";
-    }
-
-}
-.mosaico-frontpage {
-  display: grid;
   margin: 0 auto;
   min-height: 100%;
   max-width: 300px;
@@ -50,7 +28,7 @@
 
   @media (min-width: @breakpoint-3col) {
     max-width: 100%;
-    grid-template-rows: auto 85px auto 1fr 150px;
+    grid-template-rows: auto 85px auto auto auto 150px;
     // don't use repeat, causes error
     grid-template-columns: 1fr @content-block @content-block @content-block 1fr;
     grid-template-areas:
@@ -58,57 +36,10 @@
       ". head head head ."
       "separator separator separator separator separator"
       ". main main aside ."
+      ". article article article ."
       ". foot foot foot .";
   }
 }
-
-
-.mosaico-articlepage {
-  display: grid;     
-  margin: 0 auto;
-  min-height: 100%;
-  max-width: 300px;
-  grid-template-rows: 85px 1fr 150px;
-  grid-template-columns: 1fr;
-  grid-row-gap: 8px;
-  grid-template-areas:
-    "head"
-    "main"
-    "aside"
-    "foot";
-
-  @media (min-width: @breakpoint-1col-wide) {
-    max-width: calc(100% - @page-margin);
-  }
-
-  @media (min-width: @breakpoint-2col) {
-    max-width: calc((@content-block * 2) + @block-padding);
-    grid-column-gap: @block-padding;
-    // don't use repeat, causes error
-    grid-template-columns: @content-block @content-block;
-    grid-template-areas:
-      "head head"
-      "main aside"
-      "foot foot";
-  }
-
-  @media (min-width: @breakpoint-3col) {
-    max-width: 100%;
-    grid-template-rows: auto 85px auto 1fr 150px;
-    // don't use repeat, causes error
-    grid-template-columns: 1fr @content-block @content-block @content-block 1fr;
-    grid-template-areas:
-      "line line line line line"
-      ". head head head ."
-      "separator separator separator separator separator"
-      ". title title title ."
-      ". preamble preamble preamble ."
-      ". image image image ."
-      ". meta meta meta ."
-      ". main main aside ."
-      ". foot foot foot .";
-  }
-}    
 
 .mosaico--header {
   grid-area: head;
@@ -116,10 +47,6 @@
 }
 
 .mosaico--article-list {
-  grid-area: main;
-}
-
-.mosaico--article {
   grid-area: main;
 }
 

--- a/less/mosaico/_grid.less
+++ b/less/mosaico/_grid.less
@@ -1,67 +1,134 @@
-.grid {
+.mosaico {
   display: grid;
-  &.mosaico {
-    margin: 0 auto;
-    min-height: 100%;
-    max-width: 300px;
-    grid-template-rows: 85px 1fr 150px;
-    grid-template-columns: 1fr;
-    grid-row-gap: 8px;
-    grid-template-areas:
-      "head"
-      "main"
-      "aside"
-      "foot";
-
-    @media (min-width: @breakpoint-1col-wide) {
-      max-width: calc(100% - @page-margin);
-    }
-
-    @media (min-width: @breakpoint-2col) {
-      max-width: calc((@content-block * 2) + @block-padding);
-      grid-column-gap: @block-padding;
-      // don't use repeat, causes error
-      grid-template-columns: @content-block @content-block;
-      grid-template-areas:
-        "head head"
-        "main aside"
-        "foot foot";
-    }
+  grid-template-rows: auto 85px auto 1fr 150px;
+  grid-template-columns: 1fr;
+  grid-row-gap: 8px;
+  grid-template-areas:
+    "line"
+    "head"
+    "separator"
+    "main"
+    "foot";
 
     @media (min-width: @breakpoint-3col) {
-      max-width: 100%;
-      grid-template-rows: auto 85px auto 1fr 150px;
-      // don't use repeat, causes error
-      grid-template-columns: 1fr @content-block @content-block @content-block 1fr;
       grid-template-areas:
-        "line line line line line"
-        ". head head head ."
-        "separator separator separator separator separator"
-        ". main main aside ."
-        ". foot foot foot .";
+        "line line line"
+        ". head ."
+        "separator separator separator"
+        ". main ."
+        "foot foot foot";
     }
 
-    .mosaico--header {
-      grid-area: head;
-      background: @grey-light;
-    }
+}
+.mosaico-frontpage {
+  display: grid;
+  margin: 0 auto;
+  min-height: 100%;
+  max-width: 300px;
+  grid-template-columns: 1fr;
+  grid-row-gap: 8px;
+  grid-template-areas:
+    "head"
+    "main"
+    "aside"
+    "foot";
 
-    .mosaico--article-list {
-      grid-area: main;
-    }
-
-    .mosaico--article {
-      grid-area: main;
-    }
-
-    .mosaico--footer {
-      grid-area: foot;
-      background: @grey-light;
-    }
-
-    .mosaico--aside {
-      grid-area: aside;
-      background: @grey-light;
-    }
+  @media (min-width: @breakpoint-1col-wide) {
+    max-width: calc(100% - @page-margin);
   }
+
+  @media (min-width: @breakpoint-2col) {
+    max-width: calc((@content-block * 2) + @block-padding);
+    grid-column-gap: @block-padding;
+    // don't use repeat, causes error
+    grid-template-columns: @content-block @content-block;
+    grid-template-areas:
+      "head head"
+      "main aside"
+      "foot foot";
+  }
+
+  @media (min-width: @breakpoint-3col) {
+    max-width: 100%;
+    grid-template-rows: auto 85px auto 1fr 150px;
+    // don't use repeat, causes error
+    grid-template-columns: 1fr @content-block @content-block @content-block 1fr;
+    grid-template-areas:
+      "line line line line line"
+      ". head head head ."
+      "separator separator separator separator separator"
+      ". main main aside ."
+      ". foot foot foot .";
+  }
+}
+
+
+.mosaico-articlepage {
+  display: grid;     
+  margin: 0 auto;
+  min-height: 100%;
+  max-width: 300px;
+  grid-template-rows: 85px 1fr 150px;
+  grid-template-columns: 1fr;
+  grid-row-gap: 8px;
+  grid-template-areas:
+    "head"
+    "main"
+    "aside"
+    "foot";
+
+  @media (min-width: @breakpoint-1col-wide) {
+    max-width: calc(100% - @page-margin);
+  }
+
+  @media (min-width: @breakpoint-2col) {
+    max-width: calc((@content-block * 2) + @block-padding);
+    grid-column-gap: @block-padding;
+    // don't use repeat, causes error
+    grid-template-columns: @content-block @content-block;
+    grid-template-areas:
+      "head head"
+      "main aside"
+      "foot foot";
+  }
+
+  @media (min-width: @breakpoint-3col) {
+    max-width: 100%;
+    grid-template-rows: auto 85px auto 1fr 150px;
+    // don't use repeat, causes error
+    grid-template-columns: 1fr @content-block @content-block @content-block 1fr;
+    grid-template-areas:
+      "line line line line line"
+      ". head head head ."
+      "separator separator separator separator separator"
+      ". title title title ."
+      ". preamble preamble preamble ."
+      ". image image image ."
+      ". meta meta meta ."
+      ". main main aside ."
+      ". foot foot foot .";
+  }
+}    
+
+.mosaico--header {
+  grid-area: head;
+  background: @grey-light;
+}
+
+.mosaico--article-list {
+  grid-area: main;
+}
+
+.mosaico--article {
+  grid-area: main;
+}
+
+.mosaico--footer {
+  grid-area: foot;
+  background: @grey-light;
+}
+
+.mosaico--aside {
+  grid-area: aside;
+  background: @grey-light;
 }

--- a/less/mosaico/article.less
+++ b/less/mosaico/article.less
@@ -1,6 +1,23 @@
 @import (reference) "../ksf-colors";
 
-.mosaico--article {
+.article {
+  grid-area: main;
+  display: grid;
+  grid-template-columns: 100px 1fr 100px;
+  grid-template-areas:
+    ".     head  ."
+    "image image image"
+    ".     body  body";
+
+  header {
+    grid-area: head;
+  }
+  .image {
+    grid-area: image;
+  }
+  .articlebody {
+    grid-area: body;
+  }
   h1 {
     font: 700 1.92rem "Duplex Serif Web", serif;
     color: #333;
@@ -29,16 +46,18 @@
     text-transform: uppercase;
     font: 500 0.75rem "Roboto", sans-serif;
   }
-  &--preamble p {
-    font: 300 16px "Roboto", sans-serif;
-    line-height: 1.2rem;
-    @media (min-width: @breakpoint-2col) {
-      font-size: 1.25rem;
-      line-height: 1.5rem;
-    }
-    @media (min-width: @breakpoint-3col) {
-      font-size: 1.5rem;
-      line-height: 2rem;
+  &--preamble {
+    p {
+      font: 300 16px "Roboto", sans-serif;
+      line-height: 1.2rem;
+      @media (min-width: @breakpoint-2col) {
+        font-size: 1.25rem;
+        line-height: 1.5rem;
+      }
+      @media (min-width: @breakpoint-3col) {
+        font-size: 1.5rem;
+        line-height: 2rem;
+      }
     }
   }
 }

--- a/less/mosaico/article.less
+++ b/less/mosaico/article.less
@@ -1,7 +1,7 @@
 @import (reference) "../ksf-colors";
 
 .article {
-  grid-area: main;
+  grid-area: article;
   display: grid;
   grid-template-columns: 100px 1fr 100px;
   grid-template-areas:
@@ -15,9 +15,25 @@
   .image {
     grid-area: image;
   }
+
   .articlebody {
     grid-area: body;
+    display: grid;
+    @media (min-width: @breakpoint-3col) {
+      grid-template-columns: 1fr 300px;
+      grid-template-areas:
+        "articleauthors articlesidebar"
+        "articlebody articlesidebar";
+    }
   }
+
+  .mosaico--article--body {
+    grid-area: articlebody;
+  }
+  .mosaico-article-aside {
+    grid-area: articlesidebar;
+  }
+
   h1 {
     font: 700 1.92rem "Duplex Serif Web", serif;
     color: #333;
@@ -36,8 +52,6 @@
   }
   h4 {
     font: 600 1rem/1.5rem "Roboto", sans-serif;
-  }
-  &--meta {
   }
   &--premium {
     padding: 2px 5px;
@@ -75,6 +89,7 @@
 
 .mosaico--article-times-and-author {
   display: grid;
+  grid-area: articleauthors;
   grid-template-columns: auto auto;
   grid-template-rows: auto auto;
   border-style: solid;


### PR DESCRIPTION
- Use the same main Mosaico class for server and client-side rendering.
- Only show sidebar on frontpage, not on article page.
- Add sidebar to article's body (further down the page).
- Style article according to Steffen's mockups. 