### PR TITLE
Show premium/share icons row for article stubs

### DIFF
--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -120,7 +120,7 @@ render props =
                 , children: [ DOM.text $ fromMaybe mempty $ getPreamble props.article ]
                 }
             -- We don't want to be able to share error articles
-            , guard (maybe false (not <<< isErrorArticle) $ hush props.article)
+            , guard (maybe true (not <<< isErrorArticle) $ hush props.article)
                 DOM.section
                   { className: "mosaico-article__tag-n-share"
                   , children:


### PR DESCRIPTION
It would be unusual to move from article stub to a missing article, so defaulting to show the premium/share icons row would make more sense.