### PR TITLE
change line-height to correct value & remove unit

### DIFF
--- a/less/mosaico/static-pages/bruksvillkor.less
+++ b/less/mosaico/static-pages/bruksvillkor.less
@@ -17,17 +17,14 @@
 
   h2 {
     margin-bottom: 10px;
-    line-height: normal;
     text-decoration: underline;
   }
 
   h3, h4 {
     font-size: 1rem;
-    line-height: normal;
   }
 
   p {
-    text-align: justify;
     margin-top: 10px;
     margin-bottom: 10px;
   }

--- a/less/mosaico/static-pages/fragor-och-svar.less
+++ b/less/mosaico/static-pages/fragor-och-svar.less
@@ -7,7 +7,7 @@
 
   .faq__headline {
     font-size: 3.2rem;
-    line-height: 2.75rem;
+    line-height: 1;
     text-align: center;
     margin-top: 20px;
     margin-bottom: 20px;
@@ -24,7 +24,7 @@
   }
   .faq__section-headline {
     font-size: 1.75rem;
-    line-height: 1.75rem;
+    line-height: 1;
   }
 
   .faq__qa {
@@ -42,7 +42,7 @@
     text-align: start;
     outline: none;
     font-weight: 500;
-
+    line-height: 1.2;
     @media (min-width: @breakpoint-3col) {
       max-width: 90%;
     }

--- a/less/mosaico/static-pages/kundservice.less
+++ b/less/mosaico/static-pages/kundservice.less
@@ -7,7 +7,7 @@
   .customer-service__headline {
     margin: 20px 0;
     font-size: 2.2rem;
-    line-height: 2.2rem;
+    line-height: 1;
   }
 
   .customer-service__menu-buttons {

--- a/less/mosaico/static-pages/static-page.less
+++ b/less/mosaico/static-pages/static-page.less
@@ -3,7 +3,7 @@
 .mosaico--static-page {
   grid-area: main;
   font: 300  1rem "Roboto";
-  line-height: 1.2rem;
+  line-height: 1.2;
   color: #333;
 
   h1, h2 {


### PR DESCRIPTION
-for all static pages correct line-height by removing unit from line-height
-delete redundant line-height-rules
-remove justification for terms and conditions text