### PR TITLE
Restore HTML feed to vars and move them after rendered HTML

### DIFF
--- a/apps/mosaico/src/Main.js
+++ b/apps/mosaico/src/Main.js
@@ -1,18 +1,34 @@
 var cheerio = require("cheerio");
 
-// Writes mosaico html inside #app
-exports.appendMosaicoImpl = function (a, HTML_TEMPLATE) {
-  const $template = cheerio.load(HTML_TEMPLATE);
-  $template("#app").append(a);
+exports.parseTemplate = function (HTML_TEMPLATE) {
+  return cheerio.load(HTML_TEMPLATE);
+}
+
+exports.renderTemplateHtml = function ($template) {
   return $template.html();
+}
+
+exports.cloneTemplate = function ($template) {
+  return $template("html").clone();
+}
+
+// Writes mosaico html inside #app
+exports.appendMosaicoImpl = function (a, $template) {
+  $template.find("#app").append(a);
+  return $template;
 };
 
 // Writes given element under the `head` element
-exports.appendHeadImpl = function (element, HTML_TEMPLATE) {
-  const $template = cheerio.load(HTML_TEMPLATE);
-  $template("head").append(element);
-  return $template.html();
+exports.appendHeadImpl = function (element, $template) {
+  $template.find("head").append(a);
+  return $template;
 };
+
+// Appends content to body
+exports.appendVarsImpl = function (script, $template) {
+  $template.find("#app-vars").append(script);
+  return $template;
+}
 
 // Server Port
 exports.serverPort = process.env.PORT;

--- a/apps/mosaico/web/index.html
+++ b/apps/mosaico/web/index.html
@@ -49,6 +49,7 @@
   <body>
     <div id="app"></div>
     <script src="https://vjs.zencdn.net/7.17.0/video.min.js"></script>
+    <div id="app-vars"></div>
   </body>
 
   <script src="./index.js"></script>


### PR DESCRIPTION
Also retain the same Cheerio template for all content appends and only
serialize it to HTML when done.