### PR TITLE
Make backgound white to override preview bg

### DIFF
--- a/less/mosaico/_grid.less
+++ b/less/mosaico/_grid.less
@@ -1,4 +1,5 @@
 .mosaico {
+  background: white;
   display: grid;
   margin: 0 auto;
   min-height: 100%;


### PR DESCRIPTION
The Aptoma article preview puts a grey background on the iframe Mosaico is embedded in. Let's set the Mosaico bg to white for a more WYSIWYG experience.