### PR TITLE
Fix article main grid

### DIFF
--- a/less/mosaico/article.less
+++ b/less/mosaico/article.less
@@ -69,6 +69,7 @@
       "articlemetabyline"
       "articlebody";
       grid-template-columns: 1fr 300px;
+      grid-template-rows: auto 1fr;
       grid-template-areas:
         "articlemetabyline articlesidebar"
         "articlebody articlesidebar";


### PR DESCRIPTION
When the sidebar is taller than the main article content, the metabyline gets steched out. I added a `grid-template-rows` property to fix that.

See https://trello.com/c/GfWnMAJn/672-metabyline-takes-too-much-space for details.