### PR TITLE
Fix headline question to show darkmode

### DIFF
--- a/apps/app-article-server/src/browser/components/article-content.js
+++ b/apps/app-article-server/src/browser/components/article-content.js
@@ -190,7 +190,7 @@ class Content extends Component {
 
   renderQuestion(block, key) {
     return (
-      <h4 className={"headline headline-question"} key={key}>
+      <h4 className={`headline headline-question ${this.props.darkModeEnabled ? "darkMode" : ""}`} key={key}>
         <i>{block.question}</i>
       </h4>
     );


### PR DESCRIPTION
- Adds a check for darkmode in article-content.js to fix darkmode.

`<h4 className={`headline headline-question ${this.props.darkModeEnabled ? "darkMode" : ""}`} key={key}>`

![Näyttökuva 2022-04-08 100946](https://user-images.githubusercontent.com/48412269/162383359-7edbb2de-0d49-4ac0-b227-f1ac78382c75.png)
![Näyttökuva 2022-04-08 100856](https://user-images.githubusercontent.com/48412269/162383349-138d8c5d-b482-4b9b-859a-f29955f9706c.png)

