### PR TITLE
Mosaico/advertorial basic

### DIFF
--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -2,16 +2,31 @@ module Mosaico.Article.Advertorial.Basic where
 
 import Prelude
 
-import Lettera.Models (Article)
+import Data.Foldable (fold)
 import React.Basic.DOM as DOM
+import React.Basic (fragment)
 import React.Basic.Hooks (JSX)
+
+import Lettera.Models (Article)
 
 type Props = { article :: Article }
 
 render :: Props -> JSX
-render { article } =
-  DOM.article
-    { className: "mosaico-article"
-    , children:
-        [ DOM.text "ayoo" ]
+render { article } = fragment [ DOM.span { className: "advertorial-top-banner", children: [ DOM.text "ayoo" ] },
+
+    DOM.article
+        { className: "mosaico-article"
+        , children:
+            [ DOM.header_
+                [ DOM.h1
+                    { className: "mosaico-article__headline"
+                    , children: [ DOM.text article.title ]
+                    }
+                , DOM.section
+                    { className: "mosaico-article__preamble"
+                    , children: [ DOM.text $ fold article.preamble ]
+                    }
+                ]
+            ]
         }
+]

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -3,18 +3,25 @@ module Mosaico.Article.Advertorial.Basic where
 import Prelude
 
 import Data.Foldable (fold, find, foldMap)
-import React.Basic.DOM as DOM
-import React.Basic (fragment)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(..))
 import Data.String as String
-import React.Basic.Hooks (JSX)
-
 import Lettera.Models (Article)
+import Mosaico.Article.Image as Image
+import React.Basic (fragment)
+import React.Basic.DOM as DOM
+import React.Basic.Hooks (JSX, Component)
+import React.Basic.Hooks as React
 
 type Props = { article :: Article }
 
-render :: Props -> JSX
-render { article } =
+component :: Component Props
+component = do
+  imageComponent <- Image.component
+  React.component "AdvertorialBasic" \props -> React.do
+    pure $ render imageComponent props
+
+render :: (Image.Props -> JSX) -> Props -> JSX
+render imageComponent { article } =
   let companyName details
         | "companyName" <- details.title = fold details.description
         | otherwise = mempty
@@ -50,6 +57,14 @@ render { article } =
                            ]
                        }
                    ]
+                   , foldMap
+              (\image -> imageComponent
+                { clickable: true
+                , main: true
+                , params: Just "&width=960&height=540&q=90"
+                , image
+                })
+              article.mainImage
                ]
            }
         ]

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -5,8 +5,10 @@ import Prelude
 import Data.Foldable (fold, find, foldMap)
 import Data.Maybe (Maybe(..))
 import Data.String as String
-import Lettera.Models (Article)
+import KSF.Helpers (formatArticleTime)
+import Lettera.Models (Article, LocalDateTime(..))
 import Mosaico.Article.Image as Image
+import Mosaico.Article as Article
 import React.Basic (fragment)
 import React.Basic.DOM as DOM
 import React.Basic.Hooks (JSX, Component)
@@ -33,6 +35,10 @@ render imageComponent { article } =
                    { className: "advertorial-top-banner__company"
                    , children: [ DOM.text $ "ANNONS: " <> foldMap (String.toUpper <<< companyName) article.articleTypeDetails ]
                    }
+               , DOM.ul
+                   { className: "mosaico-article__some advertorial-some"
+                   , children: map Article.mkShareIcon [ "facebook", "twitter", "linkedin", "whatsapp", "mail" ]
+                   }
                ]
            }
        , DOM.article
@@ -57,14 +63,25 @@ render imageComponent { article } =
                            ]
                        }
                    ]
-                   , foldMap
-              (\image -> imageComponent
-                { clickable: true
-                , main: true
-                , params: Just "&width=960&height=540&q=90"
-                , image
-                })
-              article.mainImage
+               , foldMap
+                   (\image -> imageComponent
+                              { clickable: true
+                              , main: true
+                              , params: Just "&width=960&height=540&q=90"
+                              , image
+                              })
+                   article.mainImage
+               , DOM.div
+                   { className: "mosaico-article__main"
+                   , children:
+                       [ DOM.div
+                           { className: "mosaico-article__body"
+                           , children: map (Article.renderElement Nothing imageComponent Nothing) article.body
+                           }
+                       ]
+
+                   }
+               , DOM.div { className: "mosaico-article__aside" }
                ]
            }
-        ]
+       ]

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -22,7 +22,10 @@ render { article } =
        [ DOM.span
            { className: "advertorial-top-banner"
            , children:
-               [ DOM.span_ [ DOM.text $ "ANNONS: " <> foldMap (String.toUpper <<< companyName) article.articleTypeDetails ]
+               [ DOM.span
+                   { className: "advertorial-top-banner__company"
+                   , children: [ DOM.text $ "ANNONS: " <> foldMap (String.toUpper <<< companyName) article.articleTypeDetails ]
+                   }
                ]
            }
        , DOM.article

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -1,0 +1,17 @@
+module Mosaico.Article.Advertorial.Basic where
+
+import Prelude
+
+import Lettera.Models (Article)
+import React.Basic.DOM as DOM
+import React.Basic.Hooks (JSX)
+
+type Props = { article :: Article }
+
+render :: Props -> JSX
+render { article } =
+  DOM.article
+    { className: "mosaico-article"
+    , children:
+        [ DOM.text "ayoo" ]
+        }

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -2,9 +2,11 @@ module Mosaico.Article.Advertorial.Basic where
 
 import Prelude
 
-import Data.Foldable (fold)
+import Data.Foldable (fold, find, foldMap)
 import React.Basic.DOM as DOM
 import React.Basic (fragment)
+import Data.Maybe (Maybe)
+import Data.String as String
 import React.Basic.Hooks (JSX)
 
 import Lettera.Models (Article)
@@ -12,21 +14,30 @@ import Lettera.Models (Article)
 type Props = { article :: Article }
 
 render :: Props -> JSX
-render { article } = fragment [ DOM.span { className: "advertorial-top-banner", children: [ DOM.text "ayoo" ] },
-
-    DOM.article
-        { className: "mosaico-article"
-        , children:
-            [ DOM.header_
-                [ DOM.h1
-                    { className: "mosaico-article__headline"
-                    , children: [ DOM.text article.title ]
-                    }
-                , DOM.section
-                    { className: "mosaico-article__preamble"
-                    , children: [ DOM.text $ fold article.preamble ]
-                    }
-                ]
-            ]
-        }
-]
+render { article } =
+  let companyName details
+        | "companyName" <- details.title = fold details.description
+        | otherwise = mempty
+  in fragment
+       [ DOM.span
+           { className: "advertorial-top-banner"
+           , children:
+               [ DOM.span_ [ DOM.text $ "ANNONS: " <> foldMap (String.toUpper <<< companyName) article.articleTypeDetails ]
+               ]
+           }
+       , DOM.article
+           { className: "mosaico-article"
+           , children:
+               [ DOM.header_
+                   [ DOM.h1
+                       { className: "mosaico-article__headline"
+                       , children: [ DOM.text article.title ]
+                       }
+                   , DOM.section
+                       { className: "mosaico-article__preamble"
+                       , children: [ DOM.text $ fold article.preamble ]
+                       }
+                   ]
+               ]
+           }
+        ]

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -40,6 +40,15 @@ render { article } =
                        { className: "mosaico-article__preamble"
                        , children: [ DOM.text $ fold article.preamble ]
                        }
+                   , DOM.div
+                       { className: "advertorial__tag-n-share"
+                       , children:
+                           [ DOM.div
+                               { className: "advertorial-badge premium-badge"
+                               , children: [ DOM.span_ [ DOM.text "Annons" ] ]
+                               }
+                           ]
+                       }
                    ]
                ]
            }

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -27,7 +27,7 @@ render imageComponent { article } =
         | "companyName" <- details.title = fold details.description
         | otherwise = mempty
   in fragment
-       [ DOM.span
+       [ DOM.div
            { className: "advertorial-top-banner"
            , children:
                [ DOM.span
@@ -54,10 +54,10 @@ render imageComponent { article } =
                        , children: [ DOM.text $ fold article.preamble ]
                        }
                    , DOM.div
-                       { className: "advertorial__tag-n-share"
+                       { className: "advertorial-badge"
                        , children:
                            [ DOM.div
-                               { className: "advertorial-badge premium-badge"
+                               { className: "premium-badge"
                                , children: [ DOM.span_ [ DOM.text "Annons" ] ]
                                }
                            ]

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -2,11 +2,10 @@ module Mosaico.Article.Advertorial.Basic where
 
 import Prelude
 
-import Data.Foldable (fold, find, foldMap)
+import Data.Foldable (fold, foldMap)
 import Data.Maybe (Maybe(..))
 import Data.String as String
-import KSF.Helpers (formatArticleTime)
-import Lettera.Models (Article, LocalDateTime(..))
+import Lettera.Models (Article)
 import Mosaico.Article.Image as Image
 import Mosaico.Article as Article
 import React.Basic (fragment)

--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -42,7 +42,8 @@ render imageComponent { article } =
                ]
            }
        , DOM.article
-           { className: "mosaico-article"
+           { id: "BRAND-NEUTRAL"
+           , className: "mosaico-article"
            , children:
                [ DOM.header_
                    [ DOM.h1

--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -368,7 +368,7 @@ renderElement paper imageComponent onArticleClick el = case el of
         [ DOM.a
             { href: "/artikel/" <> article.uuid
             , children: [ DOM.text article.title ]
-            , onClick: maybe mempty (\f -> f article) onArticleClick
+            , onClick: foldMap (\f -> f article) onArticleClick
             }
         ]
 

--- a/apps/mosaico/src/Article/Box.purs
+++ b/apps/mosaico/src/Article/Box.purs
@@ -3,7 +3,7 @@ module Mosaico.Article.Box where
 import Prelude
 
 import Data.Foldable (fold)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe, maybe)
 import Data.Monoid (guard)
 import Data.String (joinWith, length)
 import KSF.Paper (Paper)
@@ -20,7 +20,7 @@ type Props =
   { title :: Maybe String
   , headline :: Maybe String
   , content :: Array String
-  , paper :: Paper
+  , paper :: Maybe Paper
   }
 
 autoExpand :: Array String -> Boolean
@@ -32,8 +32,9 @@ box = make component
   , didMount: \self ->
       self.setState \_ -> { expanded: autoExpand self.props.content }
   , render: \self ->
-      DOM.section
-        { className: "boxinfo border-" <> Paper.cssName self.props.paper
+      let paperCss = maybe "brand-neutral" Paper.cssName self.props.paper
+      in DOM.section
+        { className: "boxinfo border-" <> paperCss
         , children:
             [ DOM.header
               { className: "boxinfo__header"
@@ -41,7 +42,7 @@ box = make component
                   [ DOM.h3
                       { className: "boxinfo__label"
                       , children: [ DOM.text $ fold self.props.headline ]
-                      }   
+                      }
                   , DOM.h2
                       { className: "boxinfo__title"
                       , children: [ DOM.text $ fold self.props.title ]
@@ -63,7 +64,7 @@ box = make component
               , className: "boxinfo__toggle"
               , children: guard (not self.state.expanded) $
                   [ DOM.a
-                    { className: "color-" <> Paper.cssName self.props.paper
+                    { className: "color-" <> paperCss
                     , children: [ DOM.text "Vik ut ▼" ]
                     }
                   ]

--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -95,6 +95,7 @@ type Components =
   , searchComponent :: Search.Props -> JSX
   , webviewComponent :: Webview.Props -> JSX
   , articleComponent :: Article.Props -> JSX
+  , advertorialComponent :: Advertorial.Basic.Props -> JSX
   , epaperComponent :: Epaper.Props -> JSX
   }
 
@@ -322,6 +323,7 @@ getInitialValues = do
   searchComponent     <- Search.searchComponent
   webviewComponent    <- Webview.webviewComponent
   articleComponent    <- Article.component
+  advertorialComponent <- Advertorial.Basic.component
   epaperComponent     <- Epaper.component
   pure
     { state:
@@ -344,6 +346,7 @@ getInitialValues = do
         , searchComponent
         , webviewComponent
         , articleComponent
+        , advertorialComponent
         , epaperComponent
         }
     , catMap
@@ -408,7 +411,7 @@ render setState state components router onPaywallEvent =
            -- If we have this article already in `state`, let's pass that to `renderArticle`
            then
              if article.articleType == Advertorial
-             then Advertorial.Basic.render { article }
+             then components.advertorialComponent { article }
              else renderArticle (Right fullArticle)
            else loadingSpinner
          | Just stub <- state.clickedArticle -> mosaicoLayoutNoAside $ renderArticle $ Left stub

--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -34,9 +34,10 @@ import KSF.Spinner (loadingSpinner)
 import KSF.User (User, logout, magicLogin)
 import KSF.User.Cusno (Cusno)
 import Lettera as Lettera
-import Lettera.Models (ArticleStub, Categories, Category(..), CategoryLabel(..), CategoryType(..), FullArticle, categoriesMap, frontpageCategoryLabel, notFoundArticle, parseArticleStubWithoutLocalizing, parseArticleWithoutLocalizing, readArticleType, tagToURIComponent)
+import Lettera.Models (ArticleStub, ArticleType(..), Categories, Category(..), CategoryLabel(..), CategoryType(..), FullArticle, categoriesMap, frontpageCategoryLabel, notFoundArticle, parseArticleStubWithoutLocalizing, parseArticleWithoutLocalizing, readArticleType, tagToURIComponent)
 import Mosaico.Analytics (sendArticleAnalytics)
 import Mosaico.Article as Article
+import Mosaico.Article.Advertorial.Basic as Advertorial.Basic
 import Mosaico.Epaper as Epaper
 import Mosaico.Error as Error
 import Mosaico.Eval (ScriptTag(..), evalExternalScripts)
@@ -47,9 +48,9 @@ import Mosaico.Frontpage.Events (onFrontpageClick)
 import Mosaico.Frontpage.Models (Hook(..)) as Frontpage
 import Mosaico.Header as Header
 import Mosaico.Header.Menu as Menu
+import Mosaico.LatestList as LatestList
 import Mosaico.LoginModal as LoginModal
 import Mosaico.MostReadList as MostReadList
-import Mosaico.LatestList as LatestList
 import Mosaico.Paper (mosaicoPaper)
 import Mosaico.Profile as Profile
 import Mosaico.Routes as Routes
@@ -405,7 +406,10 @@ render setState state components router onPaywallEvent =
          | Just (Right fullArticle@{ article }) <- state.article -> mosaicoLayoutNoAside $
            if article.uuid == articleId
            -- If we have this article already in `state`, let's pass that to `renderArticle`
-           then renderArticle (Right fullArticle)
+           then
+             if article.articleType == Advertorial
+             then Advertorial.Basic.render { article }
+             else renderArticle (Right fullArticle)
            else loadingSpinner
          | Just stub <- state.clickedArticle -> mosaicoLayoutNoAside $ renderArticle $ Left stub
          | Nothing <- state.article -> mosaicoLayoutNoAside loadingSpinner

--- a/less/mosaico.less
+++ b/less/mosaico.less
@@ -27,6 +27,7 @@
 @import "mosaico/components/profile.less";
 @import "mosaico/glyphicons.less";
 @import "mosaico/components/webview.less";
+@import "mosaico/advertorial.less";
 
 #app {
     position: relative;

--- a/less/mosaico/_grid.less
+++ b/less/mosaico/_grid.less
@@ -1,3 +1,5 @@
+@grid-row-gap: 8px;
+
 .mosaico {
   background: white;
   display: grid;
@@ -5,7 +7,7 @@
   min-height: 100%;
   max-width: calc(100% - @page-margin);
   grid-template-columns: minmax(0, 1fr); //minmax used to prevent grid blowout on static pages
-  grid-row-gap: 8px;
+  grid-row-gap: @grid-row-gap;
   grid-template-areas:
     "line"
     "head"

--- a/less/mosaico/_grid.less
+++ b/less/mosaico/_grid.less
@@ -1,4 +1,5 @@
-@grid-row-gap: 8px;
+@mosaico-grid-row-gap: 8px;
+@mosaico-grid-columns: 1fr @content-block @content-block @content-block 1fr;
 
 .mosaico {
   background: white;
@@ -7,7 +8,7 @@
   min-height: 100%;
   max-width: calc(100% - @page-margin);
   grid-template-columns: minmax(0, 1fr); //minmax used to prevent grid blowout on static pages
-  grid-row-gap: @grid-row-gap;
+  grid-row-gap: @mosaico-grid-row-gap;
   grid-template-areas:
     "line"
     "head"
@@ -22,7 +23,7 @@
     max-width: 100%;
     grid-template-rows: auto 85px auto minmax(0, 60px) auto auto 500px;
     // don't use repeat, causes error
-    grid-template-columns: 1fr @content-block @content-block @content-block 1fr;
+    grid-template-columns: @mosaico-grid-columns;
     grid-template-areas:
       "line line line line line"
       ". head head head ."

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -6,6 +6,12 @@
   grid-row-start: 4;
   grid-column-start: 1;
   grid-column-end: 6;
-  margin-top: -(@grid-row-gap + @separator-margin);
-  display: flex;
+  margin-top: -(@mosaico-grid-row-gap + @separator-margin);
+  display: grid;
+  grid-template-columns: @mosaico-grid-columns;
+}
+
+.advertorial-top-banner__company {
+    grid-column-start: 2;
+    align-self: center;
 }

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -1,0 +1,10 @@
+@import (reference) "./header.less";
+@import (reference) "./_grid.less";
+
+.advertorial-top-banner {
+  background: wheat;
+  grid-row-start: 4;
+  grid-column-start: 1;
+  grid-column-end: 6;
+  margin-top: -(@grid-row-gap + @separator-margin);
+}

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -2,18 +2,38 @@
 @import (reference) "./_grid.less";
 
 .advertorial-top-banner {
-  background: #fff4e6;
-  grid-row-start: 4;
-  grid-column-start: 1;
-  grid-column-end: 6;
-  margin-top: -(@mosaico-grid-row-gap + @separator-margin);
-  display: grid;
-  grid-template-columns: @mosaico-grid-columns;
+    display: flex;
+    background: blue;
+    min-height: 100%;
+    grid-row-start: 3;
+    grid-column: 1;
+    min-height: 60px;
+  // grid-row-start: 4;
+  // grid-column-start: 1;
+  // grid-column-end: 6;
+  // margin-top: -(@mosaico-grid-row-gap + @separator-margin);
+  // display: grid;
+  // grid-template-columns: @mosaico-grid-columns;
+    @media (min-width: @breakpoint-3col) {
+	display: grid;
+	background-color: red;
+      //  background: #fff4e6;
+	grid-row-start: 4;
+	grid-column-start: 1;
+	grid-column-end: 6;
+	margin-top: -(@mosaico-grid-row-gap + @separator-margin);
+
+	grid-template-columns: @mosaico-grid-columns;
+    }
 }
 
 .advertorial-top-banner__company {
-    grid-column-start: 2;
     align-self: center;
+    width: 50%;
+    @media (min-width: @breakpoint-3col) {
+	grid-column-start: 2;
+	width: 100%;
+    }
 }
 
 .advertorial__tag-n-share {
@@ -23,7 +43,19 @@
 .advertorial-badge {
     color: black;
 }
-  .premium-badge {
-      background-color: #dfdad5 !important;
 
-  }
+.premium-badge {
+    background-color: #dfdad5 !important;
+
+}
+
+.advertorial-some {
+    display: flex;
+    @media (min-width: @breakpoint-3col) {
+	grid-column-start: 4;
+	width: 100%;
+    }
+    width: 50%;
+    justify-content: end;
+    align-self: center;
+}

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -2,60 +2,59 @@
 @import (reference) "./_grid.less";
 
 .advertorial-top-banner {
-    display: flex;
+  display: flex;
+  background: #fff4e6;
+  min-height: 100%;
+  margin-right: -@page-margin;
+  margin-left: -@page-margin;
+  grid-row-start: 3;
+  grid-column: 1;
+  min-height: 60px;
+  margin-top: @separator-height;
+  @media (min-width: @breakpoint-3col) {
+    display: grid;
+    height: 100%;
     background: #fff4e6;
-    min-height: 100%;
-    margin-right: -@page-margin;
-    margin-left: -@page-margin;
-    grid-row-start: 3;
-    grid-column: 1;
-    min-height: 60px;
-    margin-top: @separator-height;
-    @media (min-width: @breakpoint-3col) {
-	display: grid;
-	height: 100%;
-	background: #fff4e6;
-	grid-row-start: 4;
-	grid-column-start: 1;
-	grid-column-end: 6;
-	margin-top: -(@mosaico-grid-row-gap + @separator-margin);
-	grid-template-columns: @mosaico-grid-columns;
-    }
+    grid-row-start: 4;
+    grid-column-start: 1;
+    grid-column-end: 6;
+    margin-top: -(@mosaico-grid-row-gap + @separator-margin);
+    grid-template-columns: @mosaico-grid-columns;
+  }
 }
 
 .advertorial-top-banner__company {
-    align-self: center;
-    width: 50%;
-    margin-left: @page-margin;
-    @media (min-width: @breakpoint-3col) {
-	grid-column-start: 2;
-	width: 100%;
-	margin-left: 0;
-    }
+  align-self: center;
+  width: 50%;
+  margin-left: @page-margin;
+  @media (min-width: @breakpoint-3col) {
+    grid-column-start: 2;
+    width: 100%;
+    margin-left: 0;
+  }
 }
 
 .advertorial__tag-n-share {
-    display: flex;
+  display: flex;
 }
 
 .advertorial-badge {
-    color: black;
+  color: black;
 }
 
 .premium-badge {
-    background-color: #dfdad5 !important;
-
+  background-color: #dfdad5 !important;
 }
 
 .advertorial-some {
-    display: flex;
-    @media (min-width: @breakpoint-3col) {
-	grid-column-start: 4;
-	width: 100%;
-	margin-right: 0;
-    }
-    margin-right: @page-margin;
-    width: 50%;
-    justify-content: end;
-    align-self: center;
+  display: flex;
+  @media (min-width: @breakpoint-3col) {
+    grid-column-start: 4;
+    width: 100%;
+    margin-right: 0;
+  }
+  margin-right: @page-margin;
+  width: 50%;
+  justify-content: end;
+  align-self: center;
 }

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -40,9 +40,6 @@
 
 .advertorial-badge {
   color: black;
-}
-
-.premium-badge {
   background-color: #dfdad5 !important;
 }
 

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -3,26 +3,22 @@
 
 .advertorial-top-banner {
     display: flex;
-    background: blue;
+    background: #fff4e6;
     min-height: 100%;
+    margin-right: -@page-margin;
+    margin-left: -@page-margin;
     grid-row-start: 3;
     grid-column: 1;
     min-height: 60px;
-  // grid-row-start: 4;
-  // grid-column-start: 1;
-  // grid-column-end: 6;
-  // margin-top: -(@mosaico-grid-row-gap + @separator-margin);
-  // display: grid;
-  // grid-template-columns: @mosaico-grid-columns;
+    margin-top: @separator-height;
     @media (min-width: @breakpoint-3col) {
 	display: grid;
-	background-color: red;
-      //  background: #fff4e6;
+	height: 100%;
+	background: #fff4e6;
 	grid-row-start: 4;
 	grid-column-start: 1;
 	grid-column-end: 6;
 	margin-top: -(@mosaico-grid-row-gap + @separator-margin);
-
 	grid-template-columns: @mosaico-grid-columns;
     }
 }
@@ -30,9 +26,11 @@
 .advertorial-top-banner__company {
     align-self: center;
     width: 50%;
+    margin-left: @page-margin;
     @media (min-width: @breakpoint-3col) {
 	grid-column-start: 2;
 	width: 100%;
+	margin-left: 0;
     }
 }
 
@@ -54,7 +52,9 @@
     @media (min-width: @breakpoint-3col) {
 	grid-column-start: 4;
 	width: 100%;
+	margin-right: 0;
     }
+    margin-right: @page-margin;
     width: 50%;
     justify-content: end;
     align-self: center;

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -34,13 +34,12 @@
   }
 }
 
-.advertorial__tag-n-share {
-  display: flex;
-}
-
 .advertorial-badge {
-  color: black;
-  background-color: #dfdad5 !important;
+  display: flex;
+  .premium-badge {
+    color: black;
+    background-color: #dfdad5 !important;
+  }
 }
 
 .advertorial-some {

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -2,9 +2,10 @@
 @import (reference) "./_grid.less";
 
 .advertorial-top-banner {
-  background: wheat;
+  background: #fff4e6;
   grid-row-start: 4;
   grid-column-start: 1;
   grid-column-end: 6;
   margin-top: -(@grid-row-gap + @separator-margin);
+  display: flex;
 }

--- a/less/mosaico/advertorial.less
+++ b/less/mosaico/advertorial.less
@@ -15,3 +15,15 @@
     grid-column-start: 2;
     align-self: center;
 }
+
+.advertorial__tag-n-share {
+    display: flex;
+}
+
+.advertorial-badge {
+    color: black;
+}
+  .premium-badge {
+      background-color: #dfdad5 !important;
+
+  }

--- a/less/mosaico/article.less
+++ b/less/mosaico/article.less
@@ -34,17 +34,17 @@
       margin-right: -12px;
       overflow: hidden;
       @media (min-width: @breakpoint-2col) {
-        margin: 0;
+	margin: 0;
       }
       @media (min-width: @breakpoint-3col) {
-        width: 960px;
-        height: 640px;
+	width: 960px;
+	height: 640px;
       }
       img {
-        object-position: 50% 50%;
-        object-fit: cover;
-        width: 100%;
-        height: 100%;
+	object-position: 50% 50%;
+	object-fit: cover;
+	width: 100%;
+	height: 100%;
       }
     }
     .caption {
@@ -52,11 +52,11 @@
       color: @grey-medium;
       padding: 10px 0;
       .byline {
-        font-weight: 500;
-        font-size: 0.9em;
-        color: black;
-        text-transform: uppercase;
-        margin-left: 5px;
+	font-weight: 500;
+	font-size: 0.9em;
+	color: black;
+	text-transform: uppercase;
+	margin-left: 5px;
       }
     }
   }
@@ -70,8 +70,8 @@
       "articlebody";
       grid-template-columns: 1fr 300px;
       grid-template-areas:
-        "articlemetabyline articlesidebar"
-        "articlebody articlesidebar";
+	"articlemetabyline articlesidebar"
+	"articlebody articlesidebar";
     }
   }
   &__body {
@@ -134,7 +134,7 @@
     gap: 5px;
     a {
       @media (min-width: @breakpoint-3col) {
-        font-size: 0.9rem;
+	font-size: 0.9rem;
       }
     }
   }
@@ -189,13 +189,13 @@
       margin: 70px 0 30px;
 
       #HBL & {
-        color: @hbl-orange;
+	color: @hbl-orange;
       }
       #VN & {
-        color: @vn-red;
+	color: @vn-red;
       }
       #ON & {
-        color: @on-blue;
+	color: @on-blue;
       }
     }
   }
@@ -203,36 +203,36 @@
   .mosaico--article-list {
     .mosaico--list-article {
       > span {
-        min-height: 150px;
-        grid-template-areas: "left right";
-        @media (max-width: @breakpoint-2col) {
-          grid-template-columns: 1fr auto;
-          min-height: 110px;
-        }
-        grid-template-columns: auto 115px;
-        grid-column-gap: 15px;
-        .list-article-image {
-          grid-area: right;
-        }
-        .mosaico-article__tag {
-          margin-bottom: 5px;
-        }
-        h2 {
-          font: 400 1rem/1.1 "Duplex Serif Web", serif;
-          @media (min-width: @breakpoint-2col) {
-            font: 400 1.25rem/1.1 "Duplex Serif Web", serif;
-          }
-        }
+	min-height: 150px;
+	grid-template-areas: "left right";
+	@media (max-width: @breakpoint-2col) {
+	  grid-template-columns: 1fr auto;
+	  min-height: 110px;
+	}
+	grid-template-columns: auto 115px;
+	grid-column-gap: 15px;
+	.list-article-image {
+	  grid-area: right;
+	}
+	.mosaico-article__tag {
+	  margin-bottom: 5px;
+	}
+	h2 {
+	  font: 400 1rem/1.1 "Duplex Serif Web", serif;
+	  @media (min-width: @breakpoint-2col) {
+	    font: 400 1.25rem/1.1 "Duplex Serif Web", serif;
+	  }
+	}
       }
       img {
-        width: 115px;
-        height: 115px;
-        object-fit: cover;
-        @media (max-width: @breakpoint-2col) {
-          width: 75px;
-          height: 75px;
-          padding: 5px;
-        }
+	width: 115px;
+	height: 115px;
+	object-fit: cover;
+	@media (max-width: @breakpoint-2col) {
+	  width: 75px;
+	  height: 75px;
+	  padding: 5px;
+	}
       }
     }
   }
@@ -247,16 +247,16 @@
       color: @dark-text;
       text-decoration: none;
       #HBL & {
-        border-bottom: solid 1px @hbl-orange;
+	border-bottom: solid 1px @hbl-orange;
       }
       #VN & {
-        border-bottom: solid 1px @vn-red;
+	border-bottom: solid 1px @vn-red;
       }
       #ON & {
-        border-bottom: solid 1px @on-blue;
+	border-bottom: solid 1px @on-blue;
       }
       &:hover {
-        color: lighten(@dark-text, 20%);
+	color: lighten(@dark-text, 20%);
       }
     }
   }
@@ -275,13 +275,13 @@
       width: 10%;
       height: 2px;
       #HBL & {
-        background-color: @hbl-orange;
+	background-color: @hbl-orange;
       }
       #VN & {
-        background-color: @vn-red;
+	background-color: @vn-red;
       }
       #ON & {
-        background-color: @on-blue;
+	background-color: @on-blue;
       }
     }
   }
@@ -307,13 +307,13 @@
       height: 2px;
       margin: 0 auto 15px auto;
       #HBL & {
-        background-color: @hbl-orange;
+	background-color: @hbl-orange;
       }
       #VN & {
-        background-color: @vn-red;
+	background-color: @vn-red;
       }
       #ON & {
-        background-color: @on-blue;
+	background-color: @on-blue;
       }
     }
   }
@@ -330,38 +330,38 @@
       list-style: none;
       margin-top: 5px;
       li {
-        border-left: 4px solid;
-        #HBL & {
-          border-color: @hbl-orange;
-        }
-        #VN & {
-          border-color: @vn-red;
-        }
-        #ON & {
-          border-color: @on-blue;
-        }
-        margin-bottom: 3px;
-        a {
-          display: inline-block;
-          margin-left: 10px;
-          text-decoration: none;
-          color: black;
-        }
+	border-left: 4px solid;
+	#HBL & {
+	  border-color: @hbl-orange;
+	}
+	#VN & {
+	  border-color: @vn-red;
+	}
+	#ON & {
+	  border-color: @on-blue;
+	}
+	margin-bottom: 3px;
+	a {
+	  display: inline-block;
+	  margin-left: 10px;
+	  text-decoration: none;
+	  color: black;
+	}
       }
       li:first-child {
-        margin-top: 5px;
+	margin-top: 5px;
       }
     }
     ul::before {
       content: "LÄS OCKSÅ";
       #HBL & {
-        color: @hbl-orange;
+	color: @hbl-orange;
       }
       #VN & {
-        color: @vn-red;
+	color: @vn-red;
       }
       #ON & {
-        color: @on-blue;
+	color: @on-blue;
       }
     }
   }

--- a/less/mosaico/article.less
+++ b/less/mosaico/article.less
@@ -255,6 +255,9 @@
       #ON & {
 	border-bottom: solid 1px @on-blue;
       }
+      #BRAND-NEUTRAL & {
+	border-bottom: solid 1px @brand-neutral !important;
+      }
       &:hover {
 	color: lighten(@dark-text, 20%);
       }
@@ -283,6 +286,9 @@
       #ON & {
 	background-color: @on-blue;
       }
+      #BRAND-NEUTRAL & {
+	background-color: @brand-neutral !important;
+      }
     }
   }
   &__quote {
@@ -300,6 +306,9 @@
     #ON & {
       color: @on-blue;
     }
+    #BRAND-NEUTRAL & {
+      color: @brand-neutral !important;
+    }
     &::before {
       content: "";
       display: block;
@@ -314,6 +323,9 @@
       }
       #ON & {
 	background-color: @on-blue;
+      }
+      #BRAND-NEUTRAL & {
+	background-color: @brand-neutral !important;
       }
     }
   }
@@ -340,6 +352,9 @@
 	#ON & {
 	  border-color: @on-blue;
 	}
+	#BRAND-NEUTRAL & {
+	  border-color: @brand-neutral !important;
+	}
 	margin-bottom: 3px;
 	a {
 	  display: inline-block;
@@ -362,6 +377,9 @@
       }
       #ON & {
 	color: @on-blue;
+      }
+      #BRAND-NEUTRAL & {
+	color: @brand-neutral !important;
       }
     }
   }

--- a/less/mosaico/article.less
+++ b/less/mosaico/article.less
@@ -34,17 +34,17 @@
       margin-right: -12px;
       overflow: hidden;
       @media (min-width: @breakpoint-2col) {
-	margin: 0;
+        margin: 0;
       }
       @media (min-width: @breakpoint-3col) {
-	width: 960px;
-	height: 640px;
+        width: 960px;
+        height: 640px;
       }
       img {
-	object-position: 50% 50%;
-	object-fit: cover;
-	width: 100%;
-	height: 100%;
+        object-position: 50% 50%;
+        object-fit: cover;
+        width: 100%;
+        height: 100%;
       }
     }
     .caption {
@@ -52,11 +52,11 @@
       color: @grey-medium;
       padding: 10px 0;
       .byline {
-	font-weight: 500;
-	font-size: 0.9em;
-	color: black;
-	text-transform: uppercase;
-	margin-left: 5px;
+        font-weight: 500;
+        font-size: 0.9em;
+        color: black;
+        text-transform: uppercase;
+        margin-left: 5px;
       }
     }
   }
@@ -66,12 +66,12 @@
     @media (min-width: @breakpoint-2col) {
       display: grid;
       grid-template-areas:
-      "articlemetabyline"
-      "articlebody";
+        "articlemetabyline"
+        "articlebody";
       grid-template-columns: 1fr 300px;
       grid-template-areas:
-	"articlemetabyline articlesidebar"
-	"articlebody articlesidebar";
+        "articlemetabyline articlesidebar"
+        "articlebody articlesidebar";
     }
   }
   &__body {
@@ -134,7 +134,7 @@
     gap: 5px;
     a {
       @media (min-width: @breakpoint-3col) {
-	font-size: 0.9rem;
+        font-size: 0.9rem;
       }
     }
   }
@@ -189,13 +189,13 @@
       margin: 70px 0 30px;
 
       #HBL & {
-	color: @hbl-orange;
+        color: @hbl-orange;
       }
       #VN & {
-	color: @vn-red;
+        color: @vn-red;
       }
       #ON & {
-	color: @on-blue;
+        color: @on-blue;
       }
     }
   }
@@ -203,36 +203,36 @@
   .mosaico--article-list {
     .mosaico--list-article {
       > span {
-	min-height: 150px;
-	grid-template-areas: "left right";
-	@media (max-width: @breakpoint-2col) {
-	  grid-template-columns: 1fr auto;
-	  min-height: 110px;
-	}
-	grid-template-columns: auto 115px;
-	grid-column-gap: 15px;
-	.list-article-image {
-	  grid-area: right;
-	}
-	.mosaico-article__tag {
-	  margin-bottom: 5px;
-	}
-	h2 {
-	  font: 400 1rem/1.1 "Duplex Serif Web", serif;
-	  @media (min-width: @breakpoint-2col) {
-	    font: 400 1.25rem/1.1 "Duplex Serif Web", serif;
-	  }
-	}
+        min-height: 150px;
+        grid-template-areas: "left right";
+        @media (max-width: @breakpoint-2col) {
+          grid-template-columns: 1fr auto;
+          min-height: 110px;
+        }
+        grid-template-columns: auto 115px;
+        grid-column-gap: 15px;
+        .list-article-image {
+          grid-area: right;
+        }
+        .mosaico-article__tag {
+          margin-bottom: 5px;
+        }
+        h2 {
+          font: 400 1rem/1.1 "Duplex Serif Web", serif;
+          @media (min-width: @breakpoint-2col) {
+            font: 400 1.25rem/1.1 "Duplex Serif Web", serif;
+          }
+        }
       }
       img {
-	width: 115px;
-	height: 115px;
-	object-fit: cover;
-	@media (max-width: @breakpoint-2col) {
-	  width: 75px;
-	  height: 75px;
-	  padding: 5px;
-	}
+        width: 115px;
+        height: 115px;
+        object-fit: cover;
+        @media (max-width: @breakpoint-2col) {
+          width: 75px;
+          height: 75px;
+          padding: 5px;
+        }
       }
     }
   }
@@ -247,19 +247,19 @@
       color: @dark-text;
       text-decoration: none;
       #HBL & {
-	border-bottom: solid 1px @hbl-orange;
+        border-bottom: solid 1px @hbl-orange;
       }
       #VN & {
-	border-bottom: solid 1px @vn-red;
+        border-bottom: solid 1px @vn-red;
       }
       #ON & {
-	border-bottom: solid 1px @on-blue;
+        border-bottom: solid 1px @on-blue;
       }
       #BRAND-NEUTRAL & {
-	border-bottom: solid 1px @brand-neutral !important;
+        border-bottom: solid 1px @brand-neutral !important;
       }
       &:hover {
-	color: lighten(@dark-text, 20%);
+        color: lighten(@dark-text, 20%);
       }
     }
   }
@@ -278,16 +278,16 @@
       width: 10%;
       height: 2px;
       #HBL & {
-	background-color: @hbl-orange;
+        background-color: @hbl-orange;
       }
       #VN & {
-	background-color: @vn-red;
+        background-color: @vn-red;
       }
       #ON & {
-	background-color: @on-blue;
+        background-color: @on-blue;
       }
       #BRAND-NEUTRAL & {
-	background-color: @brand-neutral !important;
+        background-color: @brand-neutral !important;
       }
     }
   }
@@ -316,16 +316,16 @@
       height: 2px;
       margin: 0 auto 15px auto;
       #HBL & {
-	background-color: @hbl-orange;
+        background-color: @hbl-orange;
       }
       #VN & {
-	background-color: @vn-red;
+        background-color: @vn-red;
       }
       #ON & {
-	background-color: @on-blue;
+        background-color: @on-blue;
       }
       #BRAND-NEUTRAL & {
-	background-color: @brand-neutral !important;
+        background-color: @brand-neutral !important;
       }
     }
   }
@@ -342,44 +342,44 @@
       list-style: none;
       margin-top: 5px;
       li {
-	border-left: 4px solid;
-	#HBL & {
-	  border-color: @hbl-orange;
-	}
-	#VN & {
-	  border-color: @vn-red;
-	}
-	#ON & {
-	  border-color: @on-blue;
-	}
-	#BRAND-NEUTRAL & {
-	  border-color: @brand-neutral !important;
-	}
-	margin-bottom: 3px;
-	a {
-	  display: inline-block;
-	  margin-left: 10px;
-	  text-decoration: none;
-	  color: black;
-	}
+        border-left: 4px solid;
+        #HBL & {
+          border-color: @hbl-orange;
+        }
+        #VN & {
+          border-color: @vn-red;
+        }
+        #ON & {
+          border-color: @on-blue;
+        }
+        #BRAND-NEUTRAL & {
+          border-color: @brand-neutral !important;
+        }
+        margin-bottom: 3px;
+        a {
+          display: inline-block;
+          margin-left: 10px;
+          text-decoration: none;
+          color: black;
+        }
       }
       li:first-child {
-	margin-top: 5px;
+        margin-top: 5px;
       }
     }
     ul::before {
       content: "LÄS OCKSÅ";
       #HBL & {
-	color: @hbl-orange;
+        color: @hbl-orange;
       }
       #VN & {
-	color: @vn-red;
+        color: @vn-red;
       }
       #ON & {
-	color: @on-blue;
+        color: @on-blue;
       }
       #BRAND-NEUTRAL & {
-	color: @brand-neutral !important;
+        color: @brand-neutral !important;
       }
     }
   }

--- a/less/mosaico/components/box.less
+++ b/less/mosaico/components/box.less
@@ -30,10 +30,10 @@
       height: @collapse-height;
       width: 100%;
       background: linear-gradient(
-        0deg,
-        rgba(247, 245, 243, 1) 0%,
-        rgba(247, 245, 243, 0.5) 40%,
-        rgba(247, 245, 243, 0) 100%
+	0deg,
+	rgba(247, 245, 243, 1) 0%,
+	rgba(247, 245, 243, 0.5) 40%,
+	rgba(247, 245, 243, 0) 100%
       );
     }
     .boxinfo-body__content {
@@ -54,4 +54,8 @@
       font: 600 1rem 'Roboto';
     }
   }
+}
+
+.border-brand-neutral {
+    border-color: @brand-neutral;
 }

--- a/less/mosaico/header.less
+++ b/less/mosaico/header.less
@@ -62,7 +62,7 @@
     @media (min-width: @breakpoint-3col) {
       display: block;
     }
-    
+
     a {
       text-decoration: none;
       color: inherit;
@@ -171,7 +171,7 @@
   }
 
   &__icon-button {
-    
+
     &--search {
       align-items: center;
       display: flex;
@@ -239,10 +239,12 @@
   background-color: @grey-almostlight;
   width: 100%;
   height: 4px;
-  margin-bottom: 15px;
+  margin-bottom: @separator-margin;
 
   @media (max-width: @breakpoint-3col) {
     width: calc(100% + 24px);
     margin-left: -12px;
   }
 }
+
+@separator-margin: 15px;

--- a/less/mosaico/header.less
+++ b/less/mosaico/header.less
@@ -238,7 +238,7 @@
   margin: 0px;
   background-color: @grey-almostlight;
   width: 100%;
-  height: 4px;
+  height: @separator-height;
   margin-bottom: @separator-margin;
 
   @media (max-width: @breakpoint-3col) {
@@ -248,3 +248,4 @@
 }
 
 @separator-margin: 15px;
+@separator-height: 4px;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dhall-to-json-cli": "^1.7.6",
     "dhall-to-yaml-cli": "^1.7.6",
     "parcel-bundler": "^1.12.4",
-    "purescript": "^0.14.4",
+    "purescript": "^0.14.9",
     "react-router-dom": "^5.2.0",
     "spago": "^0.19.1",
     "uglify-es": "^3.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8708,10 +8708,10 @@ purescript-installer@^0.2.0:
     which "^1.3.1"
     zen-observable "^0.8.14"
 
-purescript@^0.14.4:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.5.tgz#5084e5dc3a543b761984afc3ff0fb20c994cea40"
-  integrity sha512-bJriK+8MssEsk++itpHL1FgqbgqxoWPgyLIkoC54k7g2Wfsj8M1svQcXcRSu1UZRixu+pg7COQF7uDref/nO2Q==
+purescript@^0.14.9:
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.9.tgz#fc4700aa66fb878a20b8bc33cc00919a34b9da48"
+  integrity sha512-r0J2JX/QuKYBSj8LDDYKQAY+tz/RtIm9erHrqWV7Y8RpUc6TZu14AxWcnSrohbBcEXImY/o0pMpouZrUeyriKQ==
   dependencies:
     purescript-installer "^0.2.0"
 


### PR DESCRIPTION
Add template for advertorial type "Basic". 

Does not know about any other templates yet, meaning, if the `articleType == Advertorial`, the basic template is rendered.

Also, unlike in the layout:
- authors and timestamps are not shown (as they aren't on the current sites either).
- company image is not shown in sidebar
- we have no way of identifying read time, so that's not there

A test article id: 19e687d3-16cc-4199-aea4-86033d43e125