### PR TITLE
Remove duplicate refreshing of ad slots

### DIFF
--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -664,6 +664,5 @@ render setState state components router onPaywallEvent =
       router.pushState (write {}) $ "/sök?q=" <> query
 
     simpleRoute path = do
-      runEffectFn1 refreshAdsImpl ["mosaico-ad__top-parade", "mosaico-ad__parade"]
       void $ Web.scroll 0 0 =<< Web.window
       router.pushState (write {}) path


### PR DESCRIPTION
After moving the ad refreshing code inside the `routeListener`, it was still left in the previous place in the `simpleRoute` function by mistake. This caused ad slots to be refreshed twice on route changes and chrome started to throw a bunch of warnings and displaying some weird ad behaviour.