### PR TITLE
Remove mosaico from list of production apps

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
       - id: deploy-app-article-server
         name: Deploy App article server
-        uses: "google-github-actions/deploy-appengine@main"
+        uses: "google-github-actions/deploy-appengine@v0.8.0"
         with:
           credentials: "${{ secrets.GCP_STAGING_AE_KEY }}"
           project_id: ksf-staging
@@ -198,70 +198,70 @@ jobs:
             cp -R apps/prenumerera/dist build/prenumerera
         shell: bash
       - name: Upload Mosaico
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/mosaico"
           parent: 'false'
           path: build/mosaico
       - name: Upload Scripts
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/scripts"
           parent: 'false'
           path: build/scripts
       - name: Upload Mitt Konto
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/mitt-konto"
           parent: 'false'
           path: build/mitt-konto
       - name: "Upload Vetrina (for testing only)"
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/vetrina-test"
           parent: 'false'
           path: build/vetrina-test
       - name: "Upload Elections (EU)"
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/elections-eu"
           parent: 'false'
           path: build/elections-eu
       - name: "Upload Elections (Parliament)"
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/elections"
           parent: 'false'
           path: build/elections
       - name: Upload App article
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/app-article"
           parent: 'false'
           path: build/app-article
       - name: Upload Corona banner
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/corona-banner"
           parent: 'false'
           path: build/corona-banner
       - name: Upload HBL365
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/hbl365"
           parent: 'false'
           path: build/hbl365
       - name: Upload Prenumerera
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PREVIEW_KEY }}"
           destination: "deploy-previews/${{ github.sha }}/prenumerera"

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
       - id: deploy-app-article-server-production
         name: Deploy App article server
-        uses: "google-github-actions/deploy-appengine@main"
+        uses: "google-github-actions/deploy-appengine@v0.8.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_AE_KEY }}"
           project_id: ksf-production
@@ -93,7 +93,7 @@ jobs:
             cat dispatch.yaml
         shell: bash
       - name: Deploy AppEngine domain map
-        uses: "google-github-actions/deploy-appengine@main"
+        uses: "google-github-actions/deploy-appengine@v0.8.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_AE_KEY }}"
           deliverables: dispatch.yaml
@@ -116,13 +116,6 @@ jobs:
       - run: |2
             yarn install --pure-lockfile
             mkdir -p build
-      - name: Setup build cache for Mosaico
-        uses: "actions/cache@v2"
-        with:
-          key: "${{ runner.os }}-mosaico-${{ hashFiles('apps/mosaico/yarn.lock')}}"
-          path: |
-            apps/mosaico/.spago
-            apps/mosaico/output
       - name: Setup build cache for Mitt Konto
         uses: "actions/cache@v2"
         with:
@@ -156,21 +149,6 @@ jobs:
           path: |
             apps/hbl365/.spago
             apps/hbl365/output
-      - env:
-          BOTTEGA_URL: https://bottega.staging.ksfmedia.fi/v1
-          ENTITLED_PASSWORD: password
-          ENTITLED_USER: "stan.marsh@skug.fi"
-          INSECURE_COOKIE: '1'
-          LETTERA_URL: https://lettera.staging.ksfmedia.fi/v4beta
-          PERSONA_URL: https://persona.staging.ksfmedia.fi/v1
-          PORT: '8080'
-          TEST_PASSWORD: password
-          TEST_USER: "wendy.testaburger@skug.fi"
-        name: Build Mosaico
-        run: |2
-            ruby deploy.rb mosaico
-            cp -R apps/mosaico/dist build/mosaico
-        shell: bash
       - name: Build Scripts
         run: |2
             ruby deploy.rb scripts
@@ -231,71 +209,64 @@ jobs:
             ruby deploy.rb prenumerera
             cp -R apps/prenumerera/dist build/prenumerera
         shell: bash
-      - name: Upload Mosaico
-        uses: "google-github-actions/upload-cloud-storage@main"
-        with:
-          credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
-          destination: ksf-frontends/mosaico
-          parent: 'false'
-          path: build/mosaico
       - name: Upload Scripts
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/scripts
           parent: 'false'
           path: build/scripts
       - name: Upload Mitt Konto
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/mitt-konto
           parent: 'false'
           path: build/mitt-konto
       - name: "Upload Vetrina (for testing only)"
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/vetrina-test
           parent: 'false'
           path: build/vetrina-test
       - name: "Upload Elections (EU)"
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/elections-eu
           parent: 'false'
           path: build/elections-eu
       - name: "Upload Elections (Parliament)"
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/elections
           parent: 'false'
           path: build/elections
       - name: Upload App article
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/app-article
           parent: 'false'
           path: build/app-article
       - name: Upload Corona banner
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/corona-banner
           parent: 'false'
           path: build/corona-banner
       - name: Upload HBL365
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/hbl365
           parent: 'false'
           path: build/hbl365
       - name: Upload Prenumerera
-        uses: "google-github-actions/upload-cloud-storage@main"
+        uses: "google-github-actions/upload-cloud-storage@v0.9.0"
         with:
           credentials: "${{ secrets.GCP_PRODUCTION_KEY }}"
           destination: ksf-frontends/prenumerera

--- a/ci/apps.dhall
+++ b/ci/apps.dhall
@@ -10,9 +10,10 @@ let App =
           , env : Map Text Text
           , lockfile : Optional Text
           , caches : Optional Text
+          , production : Bool
           }
       , default =
-        { env = [] : Map Text Text, lockfile = None Text, caches = None Text }
+        { env = [] : Map Text Text, lockfile = None Text, caches = None Text, production = True }
       }
 
 let apps =
@@ -21,6 +22,7 @@ let apps =
           , buildDir = "mosaico"
           , deployDir = "mosaico"
           , lockfile = Some "yarn.lock"
+          , production = False
           , env = toMap
               { LETTERA_URL = "https://lettera.staging.ksfmedia.fi/v4beta"
               , BOTTEGA_URL = "https://bottega.staging.ksfmedia.fi/v1"

--- a/ci/ci-master.dhall
+++ b/ci/ci-master.dhall
@@ -9,9 +9,10 @@ let Actions = ./workflows.dhall
 
 let A = ./apps.dhall
 
-let apps = A.apps
-
 let App = A.App
+
+let apps = Prelude.List.filter App.Type (\(a: App.Type) -> a.production)  A.apps
+
 
 let AE = ./app-servers.dhall
 

--- a/ci/workflows.dhall
+++ b/ci/workflows.dhall
@@ -132,7 +132,7 @@ let mkUploadStep =
       \(app : App.Type) ->
         Step::{
         , name = Some "Upload ${app.name}"
-        , uses = Some "google-github-actions/upload-cloud-storage@main"
+        , uses = Some "google-github-actions/upload-cloud-storage@v0.9.0"
         , `with` = toMap
             { path = "build/${app.deployDir}"
             , destination =
@@ -164,7 +164,7 @@ let mkAppEngineStep =
               }
               env
         , name = Some "Deploy ${app.name}"
-        , uses = Some "google-github-actions/deploy-appengine@main"
+        , uses = Some "google-github-actions/deploy-appengine@v0.8.0"
         , `with` = toMap
             { working_directory = "build/${app.deployDir}"
             , promote
@@ -185,7 +185,7 @@ let deployDispatchYamlStep =
       \(env : Env) ->
         Step::{
         , name = Some "Deploy AppEngine domain map"
-        , uses = Some "google-github-actions/deploy-appengine@main"
+        , uses = Some "google-github-actions/deploy-appengine@v0.8.0"
         , `with` = toMap
             { deliverables = "dispatch.yaml"
             , project_id =


### PR DESCRIPTION
also pins all action "imports" to a version instead of `master` or `main`