### PR TITLE
Fix facbox header and body font

### DIFF
--- a/less/mosaico/article.less
+++ b/less/mosaico/article.less
@@ -32,7 +32,7 @@
       ". image image image ."
       ". body  body  body  .";
   }
-  header {
+  > header {
     grid-area: head;
     margin-bottom: 15px;
     @media (min-width: @breakpoint-3col) {

--- a/less/mosaico/components/box.less
+++ b/less/mosaico/components/box.less
@@ -16,7 +16,7 @@
   }
   &__title {
     margin: 0;
-    font: 500 1rem 'Duplex Sans';
+    font: 500 1.2rem 'Duplex Sans';
   }
   &__body {
     height: @collapse-height;
@@ -39,6 +39,9 @@
     .boxinfo-body__content {
       position: absolute;
       z-index: 1;
+    }
+    &--expanded {
+      font: 300 1rem/1.5rem "Roboto", sans-serif;
     }
   }
   .boxinfo-body__content {


### PR DESCRIPTION
- Make article header css more specific so it doesn't affect the fact box header
- Make expanded fact box body font same as non-expanded
- Increase fact box header font-size a bit

(article to test with: /artikel/23b8c2ce-b5fb-4298-a8a8-6fbf4abb866e)