### PR TITLE
Rewrite header

### DIFF
--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -625,8 +625,7 @@ render setState state components router onPaywallEvent =
           { className: "mosaico grid " <> extraClasses
           , id: Paper.toString mosaicoPaper
           , children:
-              [ Header.topLine
-              , components.headerComponent
+              [ components.headerComponent
                   { router
                   , categoryStructure: state.categoryStructure
                   , catMap: state.catMap
@@ -636,7 +635,6 @@ render setState state components router onPaywallEvent =
                   , onProfile
                   , onStaticPageClick
                   }
-              , Header.mainSeparator
               , guard state.showAds Mosaico.ad { contentUnit: "mosaico-ad__parade" }
               , content
               , footer mosaicoPaper onStaticPageClick

--- a/apps/mosaico/src/Mosaico/Header.js
+++ b/apps/mosaico/src/Mosaico/Header.js
@@ -1,0 +1,3 @@
+exports.getBoundingClientRectTop = function(e) {
+    return e.getBoundingClientRect().top;
+}

--- a/apps/mosaico/src/Mosaico/Header.purs
+++ b/apps/mosaico/src/Mosaico/Header.purs
@@ -2,18 +2,17 @@ module Mosaico.Header
   ( Props
   , component
   , render
-  , mainSeparator
-  , topLine
   ) where
 
 import Prelude
+import Control.Bind ((>>=))
 import Data.Array (head, splitAt)
 import Data.Either (Either(..))
 import Data.Foldable (foldMap)
 import Data.Int (ceil)
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Newtype (unwrap)
-import Data.Nullable (toMaybe)
+import Data.Nullable (Nullable, null, toMaybe)
 import Data.String as String
 import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
@@ -34,25 +33,34 @@ import Routing.PushState (PushStateInterface)
 import Simple.JSON (E, read, write)
 import Web.Event.Event (EventType(..))
 import Web.Event.EventTarget (addEventListener, eventListener, removeEventListener)
+import Web.DOM (Node) as DOM
+import Web.DOM.Document (toNonElementParentNode)
+import Web.DOM.NonElementParentNode (getElementById)
+import Web.DOM.Element (clientTop)
 import Web.HTML (window)
-import Web.HTML.Window (scroll, scrollY, toEventTarget)
+import Web.HTML.Window (scroll, scrollY, toEventTarget, document)
+import Web.HTML.HTMLDocument (toDocument)
+import Web.HTML.HTMLElement (HTMLElement, fromNode, fromElement, offsetTop)
+import Effect.Uncurried (EffectFn1, runEffectFn1)
 
-type Props
-  = { router :: PushStateInterface
-    , categoryStructure :: Array Category
-    , catMap :: Categories
-    , onCategoryClick :: Category -> EventHandler
-    , onLogin :: EventHandler
-    , onProfile :: EventHandler
-    , onStaticPageClick :: String -> EventHandler
-    -- Nothing for loading state, Just Nothing for no user
-    , user :: Maybe (Maybe User)
-    }
+foreign import getBoundingClientRectTop :: EffectFn1 HTMLElement Number
+
+type Props =
+  { router :: PushStateInterface
+  , categoryStructure :: Array Category
+  , catMap :: Categories
+  , onCategoryClick :: Category -> EventHandler
+  , onLogin :: EventHandler
+  , onProfile :: EventHandler
+  , onStaticPageClick :: String -> EventHandler
+  , user :: Maybe (Maybe User)
+  }
 
 component :: React.Component Props
 component = do
   React.component "Header"
     $ \props -> React.do
+        headerPosition /\ setHeaderPosition <- React.useState 0
         scrollPosition /\ setScrollPosition <- React.useState 0
         React.useEffect unit do
           w <- window
@@ -61,6 +69,14 @@ component = do
               ( \_ -> do
                   yPosition <- scrollY w
                   setScrollPosition (const $ ceil yPosition)
+                  d <- document w
+                  (getElementById "HBL" $ toNonElementParentNode $ toDocument d) >>= (\e -> pure $ e >>= fromElement)
+                    >>= case _ of
+                      Nothing -> pure unit
+                      Just node -> do
+                        rect <- (runEffectFn1 getBoundingClientRectTop) node
+                        setHeaderPosition (const $ ceil rect)
+                        pure unit
                   pure unit
               )
           addEventListener (EventType "scroll") listener false (toEventTarget w)
@@ -69,181 +85,239 @@ component = do
             $ do
                 _ <- removeEventListener (EventType "scroll") listener false (toEventTarget w)
                 removeEventListener (EventType "pageshow") listener false (toEventTarget w)
-        pure $ (render scrollPosition props)
+        pure $ (render headerPosition 0 props)
 
-render :: Int -> Props -> JSX
-render scrollPosition props =
+render :: Int -> Int -> Props -> JSX
+render headerTopPosition _ props =
   DOM.header
-    { className: "header-container" <> (if scrollPosition == 0 then "" else " static-header")
+    { className: "mosaico-header header-container" <> (if headerTopPosition >= 0 then "" else " static-header")
     , children:
-        [ DOM.div
-            { className: block
-            , children:
-                [ DOM.div
-                    { className: block <> "__left-links"
-                    , children:
-                        [ DOM.a
-                            { href: "/sida/kontakt"
-                            , onClick: props.onStaticPageClick "kontakt"
-                            , children: [ DOM.text "KONTAKTA OSS" ]
-                            }
-                        , DOM.text "|"
-                        , DOM.a
-                            { children: [ DOM.text "E-TIDNINGEN" ]
-                            , href: "/epaper"
-                            , onClick: capture_ $ props.router.pushState (write {}) "/epaper"
-                            }
-                        ]
-                    }
-                , DOM.div
-                    { className: block <> "__right-links"
-                    , children:
-                        [ DOM.ul_
-                            [ DOM.li_
-                                [ DOM.a
-                                    { children: [ DOM.text "KUNDSERVICE" ]
-                                    , href: "/sida/kundservice"
-                                    , onClick: props.onStaticPageClick "kundservice"
-                                    }
-                                ]
-                            , DOM.li_
-                                [ DOM.a
-                                    { className: block <> "__prenumerera-link"
-                                    , children: [ DOM.text "PRENUMERERA" ]
-                                    , href: "https://prenumerera.ksfmedia.fi/#/" <> String.toLower (toString mosaicoPaper)
-                                    , target: "_blank"
-                                    }
-                                ]
-                            ]
-                        ]
-                    }
-                , DOM.a
-                    { className: block <> "__logo"
-                    , href: "/"
-                    , onClick: foldMap props.onCategoryClick frontpageCategory
-                    }
-                , renderLoginLink props.user
-                , DOM.nav
-                    { className: block <> "__center-links"
-                    , children: map mkCategory headerCategories
-                    }
-                , DOM.div
-                    { className: block <> "__right-buttons"
-                    , children:
-                        [ searchButton
-                        , DOM.div
-                            { className: iconButtonClass <> " " <> menuButtonClass
-                            , children: [ DOM.span { className: iconClass <> " " <> menuIconClass }
-                                        , DOM.span
-                                            { className: "menu-label"
-                                            , children: [ DOM.text "MENY" ]
-                                            }
-                                        ]
-                                    , onClick:
-                                        handler_
-                                        $ ( \r -> do
-                                                locationState <- r.locationState
-                                                case match (routes props.catMap) locationState.pathname of
-                                                    Right MenuPage -> do
-                                                        let
-                                                          eitherState :: E { previousPath :: String }
-                                                          eitherState = read locationState.state
-                                                        case eitherState of
-                                                          Right state -> r.pushState (write {}) state.previousPath
-                                                          Left _ -> pure unit
-                                                    _ -> do
-                                                      void $ scroll 0 0 =<< window
-                                                      r.pushState (write { previousPath: locationState.pathname }) "/meny"
-                                            )
-                                            props.router
-                            }
-                        ]
-                    }
-                ]
-            }
+        [ innerContainer "top-line" topLine
+        , DOM.div {className: "top-line-separator", children: []}
+        , innerContainer "first-line" firstHeaderRow
+        , DOM.div {className: "first-line-separator", children: []}
+        , innerContainer "logo" logo -- shown for only medium/large sizes here
+        , innerContainer "second-line" secondHeaderRow
+        , DOM.div {className: "second-line-separator", children: []}
+        , DOM.div {className: "header-bottom-border", children: []}
         ]
     }
   where
-    mkCategory category@(Category { label }) =
-        DOM.a
-        { href: "/" <> show label
-        , onClick: props.onCategoryClick category
-        , children: [ DOM.text $ String.toUpper $ unwrap label ]
+  innerContainer name child = DOM.div
+    { className: "header-container-inner-" <> name
+    , children: [ child ]
+    }
+  mkCategory category@(Category { label }) =
+    DOM.a
+      { href: "/" <> show label
+      , onClick: props.onCategoryClick category
+      , children: [ DOM.text $ String.toUpper $ unwrap label ]
+      }
+
+  { frontpageCategory, headerCategories } =
+    let
+      { after, before } = splitAt 1 props.categoryStructure
+    in
+      { frontpageCategory: head before, headerCategories: after }
+
+  leftLinks =
+    DOM.div
+      { className: block <> "__left-links"
+      , children:
+          [ DOM.a
+              { href: "/sida/kontakt"
+              , onClick: props.onStaticPageClick "kontakt"
+              , children: [ DOM.text "KONTAKTA OSS" ]
+              }
+          , DOM.text "|"
+          , DOM.a
+              { children: [ DOM.text "E-TIDNINGEN" ]
+              , href: "/epaper"
+              , onClick: capture_ $ props.router.pushState (write {}) "/epaper"
+              }
+          ]
+      }
+
+  rightLinks =
+    DOM.div
+      { className: block <> "__right-links"
+      , children:
+          [ DOM.ul_
+              [ DOM.li_
+                  [ DOM.a
+                      { children: [ DOM.text "KUNDSERVICE" ]
+                      , href: "/sida/kundservice"
+                      , onClick: props.onStaticPageClick "kundservice"
+                      }
+                  ]
+              , DOM.li_
+                  [ DOM.a
+                      { className: block <> "__prenumerera-link"
+                      , children: [ DOM.text "PRENUMERERA" ]
+                      , href: "https://prenumerera.ksfmedia.fi/#/" <> String.toLower (toString mosaicoPaper)
+                      , target: "_blank"
+                      }
+                  ]
+              ]
+          ]
+      }
+
+  logo =
+    DOM.div
+    { className: block <> "__logo-container"
+    , children: 
+      [DOM.a
+      { className: block <> "__logo"
+      , href: "/"
+      , onClick: foldMap props.onCategoryClick frontpageCategory
+      }
+    ]}
+
+  firstHeaderRow =
+    DOM.div
+      { className: block <> "__first-line"
+      , children:
+          [ leftLinks
+          , rightLinks
+          ]
+      }
+
+  profileLink = renderLoginLink props.user
+
+  navigationLinks =
+    DOM.nav
+      { className: block <> "__center-links"
+      , children: map mkCategory headerCategories
+      }
+
+  handleMenuClick =
+    handler_
+      $
+        ( \r -> do
+            locationState <- r.locationState
+            case match (routes props.catMap) locationState.pathname of
+              Right MenuPage -> do
+                let
+                  eitherState :: E { previousPath :: String }
+                  eitherState = read locationState.state
+                case eitherState of
+                  Right state -> r.pushState (write {}) state.previousPath
+                  Left _ -> pure unit
+              _ -> do
+                void $ scroll 0 0 =<< window
+                r.pushState (write { previousPath: locationState.pathname }) "/meny"
+        )
+          props.router
+
+  menuButton = DOM.div
+    { className: iconButtonClass <> " " <> menuButtonClass
+    , children:
+        [ DOM.span { className: iconClass <> " " <> menuIconClass }
+        , DOM.span
+            { className: "menu-label"
+            , children: [ DOM.text "MENY" ]
+            }
+        ]
+    , onClick: handleMenuClick
+    }
+
+  rightButtons =
+    DOM.div
+      { className: block <> "__right-buttons"
+      , children:
+          [ searchButton
+          , menuButton
+          ]
+      }
+
+  secondHeaderRow =
+    DOM.div
+      { className: block <> "__second-line"
+      , children:
+          [ profileLink
+          , navigationLinks
+          , logo -- shown only for mobile sizes here
+          , rightButtons
+          ]
+      }
+
+  searchButton :: JSX
+  searchButton =
+    DOM.a
+      { className: iconButtonClass <> " " <> searchButtonClass
+      , children:
+          [ DOM.span { className: iconClass <> " " <> searchIconClass }
+          , DOM.span
+              { className: "menu-label"
+              , children: [ DOM.text "SÖK" ]
+              }
+          ]
+      , href: "/sök"
+      , onClick: capture_ $ props.router.pushState (write {}) "/sök"
+      }
+
+  block = "mosaico-header"
+
+  accountElement = "__account"
+
+  accountClass = block <> accountElement
+
+  searchModifier = "--search"
+
+  menuModifier = "--menu"
+
+  iconButtonElement = "__icon-button"
+
+  iconButtonClass = block <> iconButtonElement
+
+  searchButtonClass = iconButtonClass <> searchModifier
+
+  menuButtonClass = iconButtonClass <> menuModifier
+
+  iconElement = "__icon"
+
+  iconClass = block <> iconElement
+
+  searchIconClass = iconClass <> searchModifier
+
+  menuIconClass = iconClass <> menuModifier
+
+  renderLoginLink Nothing =
+    loadingSpinner
+  renderLoginLink (Just Nothing) =
+    DOM.div
+        { children:
+            [ DOM.span
+                { className: accountClass <> "-icon"
+                , children: [ DOM.span_ [] ]
+                }
+            , DOM.span
+                { children: [ DOM.text "LOGGA IN" ]
+                , onClick: props.onLogin
+                }
+            ]
+        , onClick: props.onLogin
+        , className: accountClass <> " " <> accountClass <> "--active"
+        , _data: Object.fromFoldable [Tuple "login" "1"]
         }
-
-    { frontpageCategory, headerCategories } =
-        let
-        { after, before } = splitAt 1 props.categoryStructure
-        in
-        { frontpageCategory: head before, headerCategories: after }
-
-    searchButton :: JSX
-    searchButton = DOM.a
-                    { className: iconButtonClass <> " " <> searchButtonClass
-                    , children: [ DOM.span { className: iconClass <> " " <> searchIconClass }
-                                , DOM.span
-                                    { className: "menu-label"
-                                    , children: [ DOM.text "SÖK" ]
-                                    }
-                                ]
-                    , href: "/sök"
-                    , onClick: capture_ $ props.router.pushState (write {}) "/sök"
-                    }
-
-    block = "mosaico-header"
-
-    accountElement = "__account"
-    accountClass = block <> accountElement
-
-    searchModifier = "--search"
-    menuModifier = "--menu"
-
-    iconButtonElement = "__icon-button"
-    iconButtonClass = block <> iconButtonElement
-    searchButtonClass = iconButtonClass <> searchModifier
-    menuButtonClass = iconButtonClass <> menuModifier
-
-    iconElement = "__icon"
-    iconClass = block <> iconElement
-    searchIconClass = iconClass <> searchModifier
-    menuIconClass = iconClass <> menuModifier
-
-    renderLoginLink Nothing =
-      loadingSpinner
-    renderLoginLink (Just Nothing) =
-      DOM.div
-         { children:
-             [ DOM.span
-                 { className: accountClass <> "-icon"
-                 , children: [ DOM.span_ [] ]
-                 }
-             , DOM.span
-                 { children: [ DOM.text "LOGGA IN" ]
-                 , onClick: props.onLogin
-                 }
-             ]
-         , onClick: props.onLogin
-         , className: accountClass <> " " <> accountClass <> "--active"
-         , _data: Object.fromFoldable [Tuple "login" "1"]
-         }
-    renderLoginLink (Just (Just user)) =
-      let name = fromMaybe "INLOGGAD" $ toMaybe user.firstName
-      in DOM.a
-           { className: accountClass
-           , onClick: props.onProfile
-           , href: "/konto"
-           , children:
-               [ DOM.span
-                   { className: accountClass <> "-icon"
-                   , children: [ DOM.span_ [] ]
-                   }
-               , DOM.span
-                   { className: "menu-label"
-                   , children: [ DOM.text name ]
-                   }
-               ]
-           , _data: Object.fromFoldable [Tuple "loggedin" "1"]
-           }
+  renderLoginLink (Just (Just user)) =
+    let name = fromMaybe "INLOGGAD" $ toMaybe user.firstName
+    in DOM.a
+          { className: accountClass
+          , onClick: props.onProfile
+          , href: "/konto"
+          , children:
+              [ DOM.span
+                  { className: accountClass <> "-icon"
+                  , children: [ DOM.span_ [] ]
+                  }
+              , DOM.span
+                  { className: "menu-label"
+                  , children: [ DOM.text name ]
+                  }
+              ]
+          , _data: Object.fromFoldable [Tuple "loggedin" "1"]
+          }
 
 -- The characteristic line at the top of every KSF media's site
 topLine :: JSX

--- a/apps/mosaico/src/MosaicoServer.purs
+++ b/apps/mosaico/src/MosaicoServer.purs
@@ -62,8 +62,7 @@ render router props = DOM.div_
        { className: "mosaico grid " <> menuOpen
        , id: Paper.toString mosaicoPaper
        , children:
-           [ Header.topLine
-           , Header.render 0
+           [ Header.render 0 0
              { router
              , categoryStructure: props.categoryStructure
              , catMap: categoriesMap props.categoryStructure
@@ -73,7 +72,6 @@ render router props = DOM.div_
              , onProfile: mempty
              , onStaticPageClick: mempty
              }
-           , Header.mainSeparator
            , props.mainContent.content
            , footer mosaicoPaper mempty
            , case props.mainContent.type of

--- a/less/mosaico/_grid.less
+++ b/less/mosaico/_grid.less
@@ -10,7 +10,6 @@
   grid-template-columns: minmax(0, 1fr); //minmax used to prevent grid blowout on static pages
   grid-row-gap: @mosaico-grid-row-gap;
   grid-template-areas:
-    "line"
     "head"
     "separator"
     "search"
@@ -21,11 +20,10 @@
 
   @media (min-width: @breakpoint-3col) {
     max-width: 100%;
-    grid-template-rows: auto auto auto minmax(0, 30px) auto auto minmax(500px, auto);
+    grid-template-rows: auto auto minmax(0, 30px) auto auto minmax(500px, auto);
     // don't use repeat, causes error
     grid-template-columns: @mosaico-grid-columns;
     grid-template-areas:
-      "line line line line line"
       ". head head head ."
       "separator separator separator separator separator"
       ". search search aside ."
@@ -33,11 +31,6 @@
       "article article article article article"
       "foot foot foot foot foot";
   }
-}
-
-.mosaico--header {
-  grid-area: head;
-  background: @grey-light;
 }
 
 .mosaico-main {

--- a/less/mosaico/header.less
+++ b/less/mosaico/header.less
@@ -1,121 +1,386 @@
 @import (reference) "../ksf-colors";
 @import "./header/menu.less";
 
+@logo-size-desktop: 68px;
+@logo-size-mobile: 48px;
+@max-mobile-width: 640px;
+@font-weight: 500;
+
+@separator-margin: 15px;
+@separator-height: 2px;
+
+@header-size-top-line: 10px;
+@top-line-separator: 8px;
+@first-line-separator: 40px;
+@second-line-separator: 8px;
+@bottom-border-size: @separator-height;
+
+@header-size-large-full-first-line: 26px;
+@header-size-large-full-second-line: 20px;
+@header-logo-container-size-large-full:
+  @header-size-large-full-first-line
+  + @first-line-separator;
+@header-logo-size-large-full: 36px;
+@header-size-large-full-inner:
+  @header-size-top-line
+  + @top-line-separator
+  + @header-size-large-full-first-line
+  + @first-line-separator
+  + @header-size-large-full-second-line
+  + @second-line-separator
+  + @bottom-border-size;
+
+@header-size-large-scrolled-first-line: 26px;
+@header-logo-container-size-large-scrolled:
+  @header-size-large-scrolled-first-line;
+@header-logo-size-large-scrolled: 20px;
+@header-size-large-scrolled-second-line: 20px;
+@header-size-large-scrolled-inner:
+  @header-size-top-line
+  + @header-size-large-scrolled-first-line
+  + @header-size-large-scrolled-second-line
+  + @second-line-separator
+  + @bottom-border-size;
+
+@header-size-medium-full-first-line: 0;
+@header-size-medium-full-second-line: 20px;
+@header-logo-container-size-medium-full: 40px;
+@header-logo-size-medium-full: 26px;
+@header-size-medium-full-inner:
+  @header-size-top-line
+  + @top-line-separator
+  + @header-size-medium-full-first-line
+  + @first-line-separator
+  + @header-size-medium-full-second-line
+  + @second-line-separator
+  + @bottom-border-size;
+
+@header-size-medium-scrolled-first-line: 0;
+@header-logo-container-size-medium-scrolled: 20px;
+@header-logo-size-medium-scrolled: 20px;
+@header-size-medium-scrolled-second-line: 20px;
+@header-size-medium-scrolled-inner:
+  @header-size-top-line
+  + @top-line-separator
+  + @header-size-medium-scrolled-first-line
+  + @header-logo-container-size-medium-scrolled
+  + @header-size-medium-scrolled-second-line
+  + @second-line-separator
+  + @bottom-border-size;
+
+@header-size-small-full-first-line: 0;
+@header-size-small-full-second-line: 32px;
+@header-logo-container-size-small-full: 32px;
+@header-logo-size-small-full: 32px;
+@header-size-small-full-inner:
+  @header-size-top-line
+  + @top-line-separator
+  + @header-size-small-full-first-line
+  + @first-line-separator
+  + @header-size-small-full-second-line
+  + @second-line-separator
+  + @bottom-border-size;
+
+@header-size-small-scrolled-first-line: 0;
+@header-logo-container-size-small-scrolled: 32px;
+@header-logo-size-small-scrolled: 20px;
+@header-size-small-scrolled-second-line: 32px;
+@header-size-small-scrolled-inner:
+  @header-size-top-line
+  + @top-line-separator
+  + @header-size-small-scrolled-first-line
+  + @header-size-small-scrolled-second-line
+  + @second-line-separator
+  + @bottom-border-size;
+
+.mosaico-top-line {
+  #HBL & {
+    background-color: @hbl-orange;
+  }
+  #VN & {
+    background-color: @vn-red;
+  }
+  #ON & {
+    background-color: @on-blue;
+  }
+  border: 0px;
+  margin: 0px;
+  width: 100%;
+  height: 10px;
+}
+
 .header-container {
-  z-index: 10;
+  grid-area: head;
+  grid-column: 1 / -1;
+  background-color: white;
+  >*:not(:first-child):not(:last-child) {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
 
   display: grid;
-  grid-row-gap: @mosaico-grid-row-gap;
-  grid-template-rows: auto auto;
-  grid-template-columns: 5px minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) 5px;
 
+  grid-template-columns: minmax(0, 1fr); //minmax used to prevent grid blowout on static pages
   @media (min-width: @breakpoint-3col) {
     max-width: 100%;
     grid-template-columns: @mosaico-grid-columns;
   }
+
+  z-index: 10;
+
+  top: @header-size-large-scrolled-inner - @header-size-large-full-inner;
+  height: @header-size-large-full-inner;
+  position: sticky;
+  width: 100%;
 
   @media (max-width: @breakpoint-3col) {
     width: calc(100% + 24px);
     margin-left: -12px;
   }
 
-  grid-row: 2;
-  grid-column: 1 / span 5;
-  background-color: white;
-  padding-top: 8px;
-
   * {
-    transition: all 0.2s;
+    transition: all 0.1s;
   }
 
-  transition: all 0.2s;
+  transition: all 0.1s;
+
+  @media (max-width: @breakpoint-3col) {
+    top: @header-size-medium-scrolled-inner - @header-size-medium-full-inner;
+    height: @header-size-medium-full-inner;
+  }
+
+  @media (max-width: @breakpoint-2col) {
+    top: @header-size-small-scrolled-inner - @header-size-small-full-inner;
+    height: @header-size-small-full-inner;
+  }
 }
 
-.header-container.static-header {
+.header-container-inner-top-line {
+  grid-row: 1;
+  top: 0;
   position: sticky;
-  top: 10px;
-  border-bottom: 1px solid gray;
+  height: @header-size-top-line;
+  grid-column: 1 / -1;
+}
 
-  .mosaico-header {
-    &__logo {
-      background-size: 30px;
-      height: 26px;
+.top-line-separator {
+  grid-row: 2;
+  grid-column: 2 / -2;
+  position: sticky;
+  top: @header-size-top-line;
+  height: @top-line-separator;
+}
 
-      @media (max-width: @breakpoint-2col) {
-        height: 30px;
-      }
+.header-container-inner-first-line {
+  grid-row: 3;
+  grid-column: 2 / -2;
+  top: @header-size-top-line;
+  position: sticky;
+  height: @header-size-large-full-first-line;
+  display: flex;
+  align-items: center;
+
+  @media (max-width: @breakpoint-3col) {
+    height: @header-size-medium-full-first-line;
+    display: none;
+  }
+
+  @media (max-width: @breakpoint-2col) {
+    height: @header-size-small-full-first-line;
+    display: none;
+  }
+}
+
+.first-line-separator {
+  grid-row: 4;
+  grid-column: 2 / -2;
+  height: @first-line-separator;
+  position: relative;
+
+  @media (max-width: @breakpoint-3col) {
+    display: none;
+  }
+
+  @media (max-width: @breakpoint-2col) {
+    display: none;
+  }
+}
+
+.header-container-inner-logo {
+  grid-row: 5;
+  grid-column: 2 / -2;
+  top: @header-size-top-line + @header-size-large-scrolled-first-line;
+  position: sticky;
+  height: 0;
+
+  @media (max-width: @breakpoint-3col) {
+    top: @header-size-top-line + @header-size-medium-scrolled-first-line;
+    height: @header-logo-container-size-medium-full;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  @media (max-width: @breakpoint-2col) {
+    top: @header-size-top-line + @top-line-separator + @header-size-small-scrolled-first-line;
+    height: @header-size-small-scrolled-second-line;
+    display: none;
+  }
+}
+
+.header-container-inner-second-line {
+  grid-row: 6;
+  grid-column: 2 / -2;
+  top: @header-size-top-line + @header-size-large-scrolled-first-line;
+  position: sticky;
+  height: @header-size-large-scrolled-second-line;
+
+  @media (max-width: @breakpoint-3col) {
+    top: @header-size-top-line + @top-line-separator + @header-logo-container-size-medium-scrolled;
+    height: @header-size-medium-scrolled-second-line;
+  }
+
+  @media (max-width: @breakpoint-2col) {
+  top: @header-size-top-line + @top-line-separator + @header-size-small-scrolled-first-line;
+    height: @header-size-small-scrolled-second-line;
+  }
+  
+  .mosaico-header__logo-container {
+    display: none;
+  
+    @media (max-width: @breakpoint-2col) {
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
+  }
+}
 
-    &__right-links {
-      grid-row: 1;
-      > ul {
-        flex-direction: row;
-        justify-content: flex-end;
-        > li:first-child {
-          margin-right: 5px;
-        }
-      }
-    }
+.second-line-separator {
+  grid-row: 7;
+  grid-column: 2 / -2;
+  height: @second-line-separator;
+}
+
+.header-bottom-border {
+  grid-row: 8;
+  top: @header-size-top-line + @header-size-large-scrolled-first-line + @header-size-large-scrolled-second-line;
+  position: sticky;
+  border-bottom: @bottom-border-size solid @grey-almostlight;
+  grid-column: 1 / -1;
+
+  @media (max-width: @breakpoint-3col) {
+    top: @header-size-top-line + @header-logo-container-size-medium-scrolled + @header-size-medium-scrolled-first-line + @header-size-medium-scrolled-second-line;
+  }
+
+  @media (max-width: @breakpoint-2col) {
+    top: @header-size-top-line + @top-line-separator + @header-size-small-scrolled-first-line + @header-size-small-scrolled-second-line;
   }
 }
 
 .mosaico-header {
-  @logo-size-desktop: 68px;
-  @logo-size-mobile: 48px;
-  @max-mobile-width: 640px;
-  @font-weight: 500;
-
-  display: grid;
-  grid-column: 2 / span 3;
-
-  grid-template-rows: auto;
-  grid-template-columns: 15% 1fr 15%;
-
-  @media (min-width: @breakpoint-3col) {
-    // grid-template-rows: 1fr 55px 1fr;
-  }
-
-  .menu-label {
-    display: none;
-    @media (min-width: @breakpoint-2col) {
-      display: inline-block;
-    }
-  }
-
-  .menu-label {
-    display: none;
-    @media (min-width: @breakpoint-2col) {
-      display: inline-block;
-    }
-  }
-
   font: @font-weight 16px "Roboto", sans-serif;
 
+  &__first-line {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+
   &__left-links {
-    grid-row-start: 1;
-    grid-column: 1 / span 2;
-
-    gap: 1%;
-
     font: @font-weight 13px "Roboto", sans-serif;
     color: @grey-medium;
-
-    display: none;
-
-    @media (min-width: @breakpoint-3col) {
+    gap: 1%;
+    width: 100%;
       display: flex;
-    }
+    opacity: 0;
 
     a {
       text-decoration: none;
       color: inherit;
     }
+
+    @media (min-width: @breakpoint-3col) {
+      opacity: 1;
+    }
+  }
+
+  &__logo-container {
+    width: 100%;
+    height: @header-logo-container-size-large-full;
+    position: absolute;
+    margin: auto;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  
+    @media (max-width: @breakpoint-3col) {
+      height: @header-logo-container-size-medium-full;
+      position: unset;
+    }
+  
+    @media (max-width: @breakpoint-2col) {
+      height: @header-logo-container-size-small-full;
+    }
+  
+    .static-header & {
+      height: @header-logo-container-size-large-scrolled;
+  
+      @media (max-width: @breakpoint-3col) {
+        height: @header-logo-container-size-medium-scrolled;
+      }
+  
+      @media (max-width: @breakpoint-2col) {
+        height: @header-logo-container-size-small-scrolled;
+      }
+    }
+  }
+
+  &__logo {
+    display: block;
+    background-position: center;
+    background-size: contain;
+    background-repeat: no-repeat;
+    cursor: pointer;
+    width: 100%;
+    height: @header-logo-size-large-full;
+  
+    @media (max-width: @breakpoint-3col) {
+      height: @header-logo-size-medium-full;
+    }
+  
+    @media (max-width: @breakpoint-2col) {
+      height: @header-logo-size-small-full;
+    }
+
+    .static-header & {
+      height: @header-logo-size-large-scrolled;
+    
+      @media (max-width: @breakpoint-3col) {
+        height: @header-logo-size-medium-scrolled;
+      }
+    
+      @media (max-width: @breakpoint-2col) {
+        height: @header-logo-size-small-scrolled;
+      }
+    }
+  
+    #HBL & {
+      background-image: url("@{path-images}/logo-hbl.svg");
+    }
+  
+    #VN & {
+      background-image: url("@{path-images}/logo-vn.svg");
+    }
+  
+    #ON & {
+      background-image: url("@{path-images}/logo-on.svg");
+    }
   }
 
   &__right-links {
-    grid-row: 1 / span 2;
-    grid-column-start: 3;
-
     font: @font-weight 13px "Roboto", sans-serif;
     color: #00a1ab;
 
@@ -144,44 +409,29 @@
     }
   }
 
-  &__prenumerera-link {
-    border-radius: 3px;
-    background-color: #00a1ab;
-    color: #fff !important;
-    text-align: center;
-    padding: 3px 3px 1px 3px;
+  .static-header  &__right-links {
+      > ul {
+        flex-direction: row;
+        justify-content: flex-end;
+        > li:first-child {
+          margin-right: 5px;
+        }
+      }
+    }
+
+  &__second-line {
+    display: flex;
+    justify-content: space-between;
   }
 
-  &__logo {
-    grid-row-start: 1;
-    background-position: center;
-    background-size: @logo-size-mobile;
-    cursor: pointer;
-
-    grid-column-start: 2;
-    height: @logo-size-mobile;
-
-    #HBL & {
-      background-image: url("@{path-images}/logo-hbl.svg");
-    }
-    #VN & {
-      background-image: url("@{path-images}/logo-vn.svg");
-    }
-    #ON & {
-      background-image: url("@{path-images}/logo-on.svg");
-    }
-    background-repeat: no-repeat;
-
-    @media (min-width: @breakpoint-3col) {
-      background-size: @logo-size-desktop;
-      height: @logo-size-desktop;
+  .menu-label {
+    display: none;
+    @media (min-width: @breakpoint-2col) {
+      display: inline-block;
     }
   }
 
   &__account {
-    grid-row-start: 1;
-    align-self: center;
-    grid-column-start: 1;
     text-transform: uppercase;
     color: @grey-deepdark;
     display: flex;
@@ -223,8 +473,6 @@
   }
 
   &__center-links {
-    grid-row-start: 2;
-    grid-column-start: 2;
     color: @grey-deepdark;
 
     display: none;
@@ -249,9 +497,15 @@
     }
   }
 
+  &__prenumerera-link {
+    border-radius: 3px;
+    background-color: #00a1ab;
+    color: #fff !important;
+    text-align: center;
+    padding: 3px 3px 1px 3px;
+  }
+
   &__right-buttons {
-    grid-row-start: 1;
-    grid-column-start: 3;
     color: @grey-deepdark;
 
     display: flex;
@@ -259,10 +513,7 @@
     justify-content: flex-end;
     align-items: center;
     gap: 15px;
-
-    @media (min-width: @breakpoint-3col) {
-      grid-row-start: 2;
-    }
+    width: 150px;
   }
 
   &__icon-button {
@@ -308,61 +559,5 @@
 .mosaico-header__account {
   text-decoration: none;
   color: inherit;
+  width: 150px;
 }
-
-.mosaico-top-line {
-  z-index: 10;
-  grid-area: line;
-  position: sticky;
-  top: 0;
-  #HBL & {
-    background-color: @hbl-orange;
-  }
-  #VN & {
-    background-color: @vn-red;
-  }
-  #ON & {
-    background-color: @on-blue;
-  }
-  border: 0px;
-  margin: 0px;
-  width: 100%;
-  height: 10px;
-
-  @media (max-width: @breakpoint-3col) {
-    width: calc(100% + 24px);
-    margin-left: -12px;
-  }
-}
-
-.mosaico-main-separator {
-  grid-area: separator;
-  border: 0px;
-  margin: 0px;
-  background-color: @grey-almostlight;
-  width: 100%;
-  height: @separator-height;
-  margin-bottom: @separator-margin;
-
-  @media (max-width: @breakpoint-3col) {
-    width: calc(100% + 24px);
-    margin-left: -12px;
-  }
-}
-
-.mosaico-header .spinner--loading-spinner {
-  background: initial;
-  display: initial;
-  grid-row-start: 3;
-  margin-top: -40px;
-  @media (min-width: @breakpoint-2col) {
-    margin-top: -30px;
-  }
-}
-
-.mosaico-header__menu .mosaico-header__section .spinner--loading-spinner {
-  background: initial;
-}
-
-@separator-margin: 15px;
-@separator-height: 2px;


### PR DESCRIPTION
So this is an alternative implementation for the sticky headers. It does a bunch of things:
- Grab the header styckyness-scroll point from the beginning of the main mosaico block (so that leading ads are counted)
- Do a bunch of CSS magic with `position: sticky` which makes the header in theory a bit nicer for mobile devices, but...

This has the following problems (which is why this is a draft):
- at least iOS Safari still manages to behave not-nicely even though the sticky header should be now just fine for it
- The CSS quality is garbage
- some other minor issues eg. grabbing an element with id=HBL will fail for non-HBL