### PR TITLE
Make footer's background grey full width on mobile

### DIFF
--- a/less/mosaico/footer.less
+++ b/less/mosaico/footer.less
@@ -4,7 +4,13 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 50px 0;
+  padding: 50px 6px;
+  margin: 0 -12px;
+
+  @media (min-width: @breakpoint-3col) {
+    padding: 50px 0px;
+    margin: 0;
+  }
 }
 
 .mosaico-footer {


### PR DESCRIPTION
- Negative margin applied for mobile view
- A bit of padding applied to footer columns to give them the same margin used in an article's text
- Negative margin removed for desktop (to avoid horizontal scrolling)