### PR TITLE
Bypass router and use plain old link to go to webview categories

### DIFF
--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -683,6 +683,8 @@ render setState state components router onPaywallEvent =
       setState _ { clickedArticle = Just articleStub }
       simpleRoute $ "/artikel/" <> articleStub.uuid
 
+    onCategoryClick (Category { type: Webview }) =
+      mempty
     onCategoryClick cat@(Category c) =
       case state.route of
         Routes.CategoryPage category | category == cat -> mempty

--- a/apps/mosaico/src/Mosaico/Webview.purs
+++ b/apps/mosaico/src/Mosaico/Webview.purs
@@ -83,6 +83,8 @@ render (Just M3U8) url _ =
             , width: "1140"
             , height: "700"
             , _data: Object.fromFoldable [ Tuple "setup" "{}" ]
+            , autoPlay: true
+            , muted: true
             , children:
                 [ DOM.source
                     { src: url


### PR DESCRIPTION
According to SO postings, other people are also having trouble with
video.js when not loading the page fully.  So let's skip using router
for that and just use the a href as is.

Also, this enables autoplay for torgkamera.