### PR TITLE
Give Digihelmob same target ID as Digihel

### DIFF
--- a/apps/mosaico/web/index.js
+++ b/apps/mosaico/web/index.js
@@ -101,7 +101,7 @@ window.adSlots = {
     {
       gamId: "DIGIHELMOB",
       sizes: [300,431],
-      targetId: "mosaico-ad__digihelmob",
+      targetId: "mosaico-ad__bigbox1",
       isLazy: true
     },
     {
@@ -122,12 +122,6 @@ window.adSlots = {
       gamId: "JATTEBOX",
       sizes: [468,400],
       targetId: "mosaico-ad__bigbox2",
-      isLazy: true
-    },
-    {
-      gamId: "DIGIHELMOB",
-      sizes: [300,431],
-      targetId: "mosaico-ad__digihelmob",
       isLazy: true
     },
     {


### PR DESCRIPTION
- Give Digihelmob same target ID as Digihel
- Remove redundant (is it???) Digihelmob slot listed under desktop slots.