### PR TITLE
Show 'inga resultat' as the page header if there are no results

### DIFF
--- a/apps/mosaico/.env.test
+++ b/apps/mosaico/.env.test
@@ -1,0 +1,8 @@
+LETTERA_URL=https://lettera.staging.ksfmedia.fi/v4beta
+BOTTEGA_URL=https://bottega.staging.ksfmedia.fi/v1
+PAPER=hbl
+PERSONA_URL=https://persona.staging.ksfmedia.fi/v1
+PORT=8080
+INSECURE_COOKIE=1
+SENTRY_DSN=https://a49241519ad742e68e932c8d5770a04c@o360888.ingest.sentry.io/5175823
+DISABLE_ADS=1

--- a/apps/mosaico/src/Main.purs
+++ b/apps/mosaico/src/Main.purs
@@ -720,6 +720,7 @@ searchPage env { query: { search } } = do
     <*> parallel (Cache.getContent <$> Cache.getLatest env.cache)
   let mosaico = MosaicoServer.app
       htmlTemplate = cloneTemplate env.htmlTemplate
+      noResults = isJust query && null articles
       mosaicoString = DOM.renderToString
                         $ mosaico
                           { mainContent:
@@ -728,11 +729,12 @@ searchPage env { query: { search } } = do
                                   searchComponent { query
                                                   , doSearch: const $ pure unit
                                                   , searching: false
-                                                  , noResults: isJust query && null articles
                                                   } <>
                                   (guard (not $ null articles) $
                                    Frontpage.render $ Frontpage.List
-                                   { label: ("Sökresultat: " <> _) <$> query
+                                   { label: if noResults
+                                            then Just "Inga resultat"
+                                            else ("Sökresultat: " <> _) <$> query
                                    , content: Just articles
                                    , onArticleClick: const mempty
                                    , onTagClick: const mempty

--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -511,7 +511,7 @@ render props setState state components router onPaywallEvent =
          | otherwise -> mosaicoLayoutNoAside $ renderArticle (Right notFoundArticle)
        Routes.Frontpage -> renderFrontpage
        Routes.SearchPage Nothing ->
-          mosaicoDefaultLayout $ components.searchComponent { query: Nothing, doSearch, searching: false, noResults: false }
+          mosaicoDefaultLayout $ components.searchComponent { query: Nothing, doSearch, searching: false }
        Routes.SearchPage query@(Just queryString) ->
           let frontpageArticles = _.feed <$> HashMap.lookup (SearchFeed queryString) state.frontpageFeeds
               searching = isNothing frontpageArticles
@@ -519,9 +519,11 @@ render props setState state components router onPaywallEvent =
                 Just (ArticleList list)
                   | null list -> true
                 _             -> false
-              searchProps = { query, doSearch, searching, noResults }
+              searchProps = { query, doSearch, searching }
               header = components.searchComponent searchProps
-              label = Just $ "Sökresultat: " <> queryString
+              label = if noResults
+                      then Just "Inga resultat"
+                      else Just $ "Sökresultat: " <> queryString
           in frontpage (Just header) label frontpageArticles
        Routes.NotFoundPage _ -> mosaicoLayoutNoAside $ renderArticle (Right notFoundArticle)
        Routes.TagPage tag ->

--- a/apps/mosaico/src/Mosaico/Search.purs
+++ b/apps/mosaico/src/Mosaico/Search.purs
@@ -16,7 +16,6 @@ type Props =
   { query :: Maybe String
   , doSearch :: String -> Effect Unit
   , searching :: Boolean
-  , noResults :: Boolean
   }
 
 searchComponent :: Component Props
@@ -26,7 +25,7 @@ searchComponent = do
     pure $ render query setQuery props
 
 render :: Maybe String -> (Maybe String -> Effect Unit) -> Props -> JSX
-render query setQuery { doSearch, searching, noResults } =
+render query setQuery { doSearch, searching } =
   DOM.div
     { className: "mosaico-search"
     , children:
@@ -66,10 +65,5 @@ render query setQuery { doSearch, searching, noResults } =
                   Just "" -> pure unit
                   Just q -> doSearch q
             }
-        , guard noResults $
-            DOM.div
-              { className: "mosaico-search__message"
-              , children: [ DOM.text "Inga resultat" ]
-              }
         ]
     }

--- a/apps/mosaico/test/Search.purs
+++ b/apps/mosaico/test/Search.purs
@@ -18,8 +18,8 @@ buttonField = Chrome.Selector ".mosaico-search button"
 searchField :: Chrome.Selector
 searchField = Chrome.Selector ".mosaico-search input"
 
-messageField :: Chrome.Selector
-messageField = Chrome.Selector ".mosaico-search__message"
+pageTitle :: Chrome.Selector
+pageTitle = Chrome.Selector ".mosaico--article-list > h1"
 
 testSearchNavigation :: Test
 testSearchNavigation page = do
@@ -43,7 +43,8 @@ testExampleSearch page = do
   Chrome.click buttonField page
   log "Wait for search results"
   Chrome.waitFor_ listArticle page
-  Chrome.assertNotFound messageField page
+  Chrome.waitFor_ pageTitle page
+  Chrome.assertContent pageTitle ("Sökresultat: " <> exampleSearch) page
 
 testFailingSearch :: Test
 testFailingSearch page = do
@@ -51,6 +52,6 @@ testFailingSearch page = do
   Chrome.waitFor_ searchField page
   Chrome.type_ (Chrome.Selector ".mosaico-search input") exampleNegativeSearch page
   Chrome.click buttonField page
-  Chrome.waitFor_ messageField page
-  Chrome.assertContent messageField "Inga resultat" page
+  Chrome.waitFor_ pageTitle page
+  Chrome.assertContent pageTitle "Inga resultat" page
   Chrome.assertNotFound listArticle page


### PR DESCRIPTION
![2022-05-16-150457_1012x340_scrot](https://user-images.githubusercontent.com/91122811/168588735-b720a9f6-25c2-4422-a407-3cf7840288d7.png)

This was the old behavior:
![2022-05-16-150535_934x434_scrot](https://user-images.githubusercontent.com/91122811/168588839-07e91c64-b829-4736-ad75-f942a232e3ca.png)
