### PR TITLE
Mosaico/fix digihelmob ad slot

### DIFF
--- a/apps/mosaico/web/index.js
+++ b/apps/mosaico/web/index.js
@@ -98,12 +98,12 @@ window.adSlots = {
       targetId: "mosaico-ad__box5",
       isLazy: true
     },
-    {
-      gamId: "DIGIHELMOB",
-      sizes: [300,431],
-      targetId: "mosaico-ad__bigbox1",
-      isLazy: true
-    },
+    // {
+    //   gamId: "DIGIHELMOB",
+    //   sizes: [300,431],
+    //   targetId: "mosaico-ad__bigbox1",
+    //   isLazy: true
+    // },
     {
       gamId: "INTERMOB",
       sizes: [300,500],

--- a/apps/mosaico/web/index.js
+++ b/apps/mosaico/web/index.js
@@ -101,7 +101,7 @@ window.adSlots = {
     {
       gamId: "DIGIHELMOB",
       sizes: [300,431],
-      targetId: "mosaico-ad__digihelmob",
+      targetId: "mosaico-ad__bigbox1",
       isLazy: true
     },
     {
@@ -122,12 +122,6 @@ window.adSlots = {
       gamId: "JATTEBOX",
       sizes: [468,400],
       targetId: "mosaico-ad__bigbox2",
-      isLazy: true
-    },
-    {
-      gamId: "DIGIHELMOB",
-      sizes: [300,431],
-      targetId: "mosaico-ad__digihelmob",
       isLazy: true
     },
     {


### PR DESCRIPTION
Rolling back change which broke the ads on mobile, by removing the Digihelmob ad slot as a quick fix.