### PR TITLE
Make link underline thicker and move it closer to text

### DIFF
--- a/less/mosaico/article.less
+++ b/less/mosaico/article.less
@@ -313,18 +313,19 @@
     color: @dark-text;
     a {
       color: @dark-text;
-      text-decoration: none;
+      text-decoration-style: underline;
+      text-decoration-thickness: 2px;
       #HBL & {
-        border-bottom: solid 1px @hbl-orange;
+        text-decoration-color: @hbl-orange;
       }
       #VN & {
-        border-bottom: solid 1px @vn-red;
+        text-decoration-color: @vn-red;
       }
       #ON & {
-        border-bottom: solid 1px @on-blue;
+        text-decoration-color: @on-blue;
       }
       #BRAND-NEUTRAL & {
-        border-bottom: solid 1px @brand-neutral !important;
+        text-decoration-color: @brand-neutral !important;
       }
       &:hover {
         color: lighten(@dark-text, 20%);


### PR DESCRIPTION
- Use text-decoration instead of border-bottom because it renders closer to the text, make underline 2 px thick.

Fixes https://trello.com/c/oUV9TSdU/676-links-make-the-underlining-to-be-2-px-and-move-it-closer-to-the-link-text