### PR TITLE
Apply more rules for showing last 5 of most read and latest lists

### DIFF
--- a/less/mosaico/article-list.less
+++ b/less/mosaico/article-list.less
@@ -239,4 +239,16 @@
   @media (max-width: @breakpoint-2col) {
     display: none;
   }
+
+  #VN & {
+    display: none;
+  }
+
+  #ON & {
+    display: none;
+  }
+
+  .mosaico-article__main & {
+    display: inherit !important;
+  }
 }


### PR DESCRIPTION
VN/ÖN front page: Always 5
HBL front page: 10 on desktop, 5 on mobile
All papers, in articles: Always 10