### PR TITLE
Add .npmrc with legacy-peer-deps for every project

### DIFF
--- a/apps/app-article-server/.npmrc
+++ b/apps/app-article-server/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/app-article/.npmrc
+++ b/apps/app-article/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/corona-banner/.npmrc
+++ b/apps/corona-banner/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/duellen/.npmrc
+++ b/apps/duellen/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/elections/.npmrc
+++ b/apps/elections/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/hbl365/.npmrc
+++ b/apps/hbl365/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/mitt-konto/.npmrc
+++ b/apps/mitt-konto/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/mosaico/.npmrc
+++ b/apps/mosaico/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/podcasts/.npmrc
+++ b/apps/podcasts/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/prenumerera/.npmrc
+++ b/apps/prenumerera/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/apps/vetrina-test/.npmrc
+++ b/apps/vetrina-test/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/packages/user/.npmrc
+++ b/packages/user/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev

--- a/packages/vetrina/.npmrc
+++ b/packages/vetrina/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+include=dev


### PR DESCRIPTION
This is because npm --prefix for some reason ignores workspace-level .npmrc.