### PR TITLE
Add generic show instances for lettera models for easier debugging

### DIFF
--- a/packages/components/src/Lettera/Models.purs
+++ b/packages/components/src/Lettera/Models.purs
@@ -18,6 +18,7 @@ import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Newtype (class Newtype, un, unwrap)
+import Data.Show.Generic (genericShow)
 import Data.String (joinWith, toLower)
 import Data.String (Pattern(..), Replacement(..), replaceAll, toLower) as String
 import Data.String.Extra (kebabCase) as String
@@ -93,6 +94,9 @@ data ArticleType
   | Advertorial
 
 derive instance eqArticleType :: Eq ArticleType
+derive instance genericArticleType :: Generic ArticleType _
+instance showDataArticleType :: Show ArticleType where
+  show = genericShow
 
 articleTypes :: Array (Tuple ArticleType String)
 articleTypes =
@@ -107,6 +111,9 @@ articleTypes =
 
 newtype LocalDateTime = LocalDateTime DateTime
 derive instance newtypeLocalDateTime :: Newtype LocalDateTime _
+derive instance localDateTimeGeneric :: Generic LocalDateTime _
+instance showLocalDateTime :: Show LocalDateTime where
+  show = genericShow
 
 localizeArticleDateTimeString :: String -> String -> Effect (Maybe LocalDateTime)
 localizeArticleDateTimeString uuid dateTimeString =
@@ -157,6 +164,9 @@ type ArticleStub =
 -- when we decode/encode the thing
 newtype ExternalScript = ExternalScript String
 derive instance newtypeExternalScript :: Newtype ExternalScript _
+derive instance genericExternalScript :: Generic ExternalScript _
+instance showExternalScript :: Show ExternalScript where
+  show = genericShow
 
 instance readForeignExternalScript :: ReadForeign ExternalScript where
   readImpl f = do
@@ -418,6 +428,8 @@ data BodyElement
   | Ad Ad
   | Related (Array ArticleStub)
 derive instance bodyElementGeneric :: Generic BodyElement _
+instance bodyElementShow :: Show BodyElement where
+  show = genericShow
 
 type BoxInfo =
   { title :: Maybe String


### PR DESCRIPTION
This allows better debug printing with eg.

```
diff --git a/apps/mosaico/src/Article/Article.purs b/apps/mosaico/src/Article/Article.purs
index 8b797375..171ee943 100644
--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -33,6 +33,7 @@ import React.Basic.DOM as DOM
 import React.Basic.Events (EventHandler)
 import React.Basic.Hooks as React
 import React.Basic.Hooks (Component)
+import Debug
 
 isPremium :: Either ArticleStub FullArticle -> Boolean
 isPremium = either _.premium _.article.premium
@@ -82,7 +83,7 @@ component = do
     pure $ render imageComponent boxComponent props
 
 render :: (Image.Props -> JSX) -> (Box.Props -> JSX) -> Props -> JSX
-render imageComponent boxComponent props =
+render imageComponent boxComponent props = trace (show props.article) \_ ->
     let title = getTitle props.article
         tags = getTags props.article
         mainImage = getMainImage props.article
```