### PR TITLE
Remove doubled header separator

### DIFF
--- a/apps/mosaico/src/Mosaico/Header.purs
+++ b/apps/mosaico/src/Mosaico/Header.purs
@@ -2,7 +2,6 @@ module Mosaico.Header
   ( Props
   , component
   , render
-  , mainSeparator
   , topLine
   ) where
 

--- a/apps/mosaico/src/MosaicoServer.purs
+++ b/apps/mosaico/src/MosaicoServer.purs
@@ -57,7 +57,6 @@ render props = DOM.div_
              , onStaticPageClick: mempty
              , onMenuClick: mempty
              }
-           , Header.mainSeparator
            , props.mainContent.content
            , footer mosaicoPaper mempty
            , case props.mainContent.type of


### PR DESCRIPTION
During SSR, the server actually returns two separators instead of one.