### PR TITLE
Group article content for easier targeting

### DIFF
--- a/apps/mosaico/src/Article/Advertorial/Basic.purs
+++ b/apps/mosaico/src/Article/Advertorial/Basic.purs
@@ -73,7 +73,12 @@ render imageComponent boxComponent { article, imageProps, advertorialClassName }
                    , children:
                        [ DOM.div
                            { className: "mosaico-article__body"
-                           , children: map (Article.renderElement imageComponent boxComponent Nothing) article.body
+                           , children:
+                               [ DOM.section
+                                   { className: "article-content"
+                                   , children: map (Article.renderElement imageComponent boxComponent Nothing) article.body
+                                   }
+                               ]
                            }
                        ]
 

--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -88,8 +88,13 @@ render imageComponent boxComponent props =
         mainImage = getMainImage props.article
         body = getBody props.article
         bodyWithoutAd = map (renderElement imageComponent boxComponent (Just props.onArticleClick)) body
-        bodyWithAd = map (renderElement imageComponent boxComponent (Just props.onArticleClick))
-          <<< insertAdsIntoBodyText "mosaico-ad__bigbox1" "mosaico-ad__bigbox2" $ body
+        bodyWithAd = 
+          [ DOM.section
+            { className: "article-content"
+            , children: map (renderElement imageComponent boxComponent (Just props.onArticleClick))
+                <<< insertAdsIntoBodyText "mosaico-ad__bigbox1" "mosaico-ad__bigbox2" $ body
+            }
+          ]
         advertorial = foldMap renderAdvertorialTeaser props.advertorial
         mostRead = foldMap renderMostReadArticles $
           if null props.mostReadArticles then Nothing else Just $ take 5 props.mostReadArticles


### PR DESCRIPTION
This change makes our article pages more semantic, and makes it easier for eg @mfahler9 to target the last article element like this:

```
$$(".article-content > .article-element:last-child")
```