### PR TITLE
Remove direct eval call

### DIFF
--- a/apps/mosaico/src/Mosaico/Eval.js
+++ b/apps/mosaico/src/Mosaico/Eval.js
@@ -16,7 +16,7 @@ export function evalExternalScriptsImpl(scripts) {
 
 function evalScript(s) {
   try {
-    eval(s);
+    window.eval(s);
   } catch (err) {
     console.warn("Failed to eval script:", err);
   }


### PR DESCRIPTION
https://esbuild.github.io/content-types/#direct-eval

As far as I see, this doesn't affect the actually compiled/minified code (which is ...actually interesting, as the code using `eval()` should have a bunch of non-minified identifiers), and silences the warning.