### PR TITLE
Make headings consistent

### DIFF
--- a/apps/mosaico/src/Article/Article.purs
+++ b/apps/mosaico/src/Article/Article.purs
@@ -283,7 +283,7 @@ render imageComponent boxComponent props =
     renderMostReadArticles articles =
       DOM.div
         { className: "mosaico-article__mostread--header"
-        , children: [ DOM.text "ANDRA LÄSER" ]
+        , children: [ DOM.h2_ [DOM.text "ANDRA LÄSER" ]]
         } <>
       (Frontpage.render $ Frontpage.List
         { label: mempty
@@ -365,7 +365,7 @@ renderElement imageComponent boxComponent onArticleClick el =  case el of
     { dangerouslySetInnerHTML: { __html: content }
     , className: block <> " " <> block <> "__html"
     }
-  Headline str -> DOM.h4
+  Headline str -> DOM.h2
     { className: block <> " " <> block <> "__subheadline"
     , children: [ DOM.text str ]
     }

--- a/apps/mosaico/src/Mosaico.purs
+++ b/apps/mosaico/src/Mosaico.purs
@@ -713,6 +713,10 @@ render props setState state components router onPaywallEvent =
                           | otherwise
                           -> Routes.changeRoute router "/"
                         _ -> Routes.changeRoute router "/meny"
+                  , showHeading: case state.route of
+                        Routes.ArticlePage _ -> false
+                        Routes.StaticPage _ -> false
+                        _ -> true
                   }
               , guard showAds Mosaico.ad { contentUnit: "mosaico-ad__parade", inBody: false }
               , content

--- a/apps/mosaico/src/Mosaico/EpaperBanner.purs
+++ b/apps/mosaico/src/Mosaico/EpaperBanner.purs
@@ -12,7 +12,7 @@ render =
   in DOM.section
       { className: blockClass
       , children:
-        [ DOM.header_ [ DOM.h1_ [ DOM.text "E-tidningen" ] ]
+        [ DOM.header_ [ DOM.h2_ [ DOM.text "E-tidningen" ] ]
         , DOM.a
           { href: "/epaper"
           , className: blockClass <> "--container"

--- a/apps/mosaico/src/Mosaico/Frontpage.purs
+++ b/apps/mosaico/src/Mosaico/Frontpage.purs
@@ -97,7 +97,11 @@ render (List props) =
                                       ) $ head a.tags
                                   , DOM.a
                                       { href: "/artikel/" <> a.uuid
-                                      , children: [ DOM.h2_ [ DOM.text $ fromMaybe a.title a.listTitle] ]
+                                      , children: [ DOM.h3
+                                                      { className: "text-2xl leading-tight font-duplexserif"
+                                                      , children: [ DOM.text $ fromMaybe a.title a.listTitle ]
+                                                      }
+                                                  ]
                                       }
                                   , DOM.span
                                       { className: "list-article-timestamp"
@@ -135,8 +139,8 @@ render (Prerendered props@{ hooks }) = genericRender
 maybeLabel :: Maybe String -> JSX
 maybeLabel categoryLabel =
   case categoryLabel of
-    Just label -> DOM.h1
-                    { className: ""
+    Just label -> DOM.h2
+                    { className: "[grid-area:main] text-3xl leading-none font-roboto font-bold inline-block mb-8 border-b-2 border-brand"
                     , children: [ DOM.text label ]
                     }
     _          -> mempty

--- a/apps/mosaico/src/Mosaico/Header.purs
+++ b/apps/mosaico/src/Mosaico/Header.purs
@@ -18,7 +18,7 @@ import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
 import Effect (Effect)
 import Foreign.Object as Object
-import KSF.Paper (toString)
+import KSF.Paper (toString, paperName)
 import KSF.Spinner (loadingSpinner)
 import KSF.User (User)
 import Lettera.Models (Categories, Category(..))
@@ -44,6 +44,7 @@ type Props
     , onMenuClick :: Effect Unit
     -- Nothing for loading state, Just Nothing for no user
     , user :: Maybe (Maybe User)
+    , showHeading :: Boolean
     }
 
 component :: React.Component Props
@@ -76,7 +77,8 @@ render scrollPosition props =
         [ DOM.div
             { className: block
             , children:
-                [ DOM.div
+                [ srHeading
+                , DOM.div
                     { className: block <> "__left-links"
                     , children:
                         [ DOM.a
@@ -147,6 +149,14 @@ render scrollPosition props =
         ]
     }
   where
+    srHeading =
+        if props.showHeading
+        then DOM.h1
+               { className: "sr-only"
+               , children: [DOM.text $ paperName mosaicoPaper]
+               }
+        else mempty
+
     mkCategory category@(Category { label }) =
         DOM.a
         { href: "/" <> show label

--- a/apps/mosaico/src/Mosaico/Lists/LatestList.purs
+++ b/apps/mosaico/src/Mosaico/Lists/LatestList.purs
@@ -24,7 +24,7 @@ render props =
   in DOM.div
        { className: joinWith " " [block, block <> "__latest"]
        , children:
-           [ DOM.h3
+           [ DOM.h2
                { className: block <> "--header"
                , children: [ DOM.text "Senast publicerat" ]
                }
@@ -42,7 +42,10 @@ render props =
                 [ DOM.div
                     { className: "list-article-liftup"
                     , children:
-                        [ DOM.h6_ [ DOM.text $ fromMaybe a.title a.listTitle ]
+                        [ DOM.h3
+                            { className: "text-xl leading-tight font-duplexserif"
+                            , children: [ DOM.text $ fromMaybe a.title a.listTitle ]
+                            }
                         , foldMap (\publishingTime ->
                             DOM.span
                               { className: "mosaico-asidelist__timestamp"

--- a/apps/mosaico/src/Mosaico/Lists/MostReadList.purs
+++ b/apps/mosaico/src/Mosaico/Lists/MostReadList.purs
@@ -22,7 +22,7 @@ render props =
   in DOM.div
        { className: joinWith " " [block, block <> "__mostread"]
        , children:
-           [ DOM.h3
+           [ DOM.h2
                { className: block <> "--header"
                , children: [ DOM.text "Andra läser" ]
                }
@@ -44,7 +44,10 @@ render props =
                 , DOM.div
                     { className: "list-article-liftup"
                     , children:
-                        [ DOM.h6_ [ DOM.text $ fromMaybe a.title a.listTitle ]
+                        [ DOM.h3
+                            { className: "text-xl leading-tight font-duplexserif"
+                            , children: [ DOM.text $ fromMaybe a.title a.listTitle ]
+                            }
                         , guard a.premium $ DOM.div
                             { className: "mosaico-article__meta"
                             , children:

--- a/apps/mosaico/src/Mosaico/LoginModal.purs
+++ b/apps/mosaico/src/Mosaico/LoginModal.purs
@@ -63,7 +63,7 @@ render props state =
                 [ DOM.div
                     { className: "mosaico--login-modal_title"
                     , children:
-                        [ DOM.h1
+                        [ DOM.h2
                             { className: "mt-8 text-3xl font-bold font-roboto"
                             , children: [ DOM.text "Logga in" ]
                             }

--- a/apps/mosaico/src/MosaicoServer.purs
+++ b/apps/mosaico/src/MosaicoServer.purs
@@ -56,6 +56,7 @@ render props = DOM.div_
              , onProfile: mempty
              , onStaticPageClick: mempty
              , onMenuClick: mempty
+             , showHeading: false
              }
            , props.mainContent.content
            , footer mosaicoPaper mempty

--- a/apps/mosaico/test/Lettera.purs
+++ b/apps/mosaico/test/Lettera.purs
@@ -38,7 +38,7 @@ testListTitle page = do
       Chrome.waitFor_ listArticle page
       log "List uses listTitle"
       -- The example should have a listTitle
-      Chrome.assertContent (sub " h2" listArticle) (fromMaybe "☃INVALID" stub.listTitle) page
+      Chrome.assertContent (sub " h3" listArticle) (fromMaybe "☃INVALID" stub.listTitle) page
       Chrome.click listArticle page
       log "Article uses title"
       Chrome.waitFor_ (Chrome.Selector "article.mosaico-article") page
@@ -57,7 +57,7 @@ testDefaultListTitle page = do
     Right stub -> do
       Chrome.waitFor_ listArticle page
       log "List defaults to using title"
-      Chrome.assertContent (sub " h2" listArticle) stub.title page
+      Chrome.assertContent (sub " h3" listArticle) stub.title page
 
 -- TODO do this for other papers as well
 
@@ -91,7 +91,7 @@ testCategoryLists page = do
             Unit.failure "No common articles found in Lettera's and Mosaico's category page"
           Just {i, match} -> do
             let title = fromMaybe match.title match.listTitle
-            Chrome.assertContent (sub (":nth-child(" <> show i <> ") h2") listArticle) title page
+            Chrome.assertContent (sub (":nth-child(" <> show i <> ") h3") listArticle) title page
         Chrome.goto (Chrome.URL $ site <> "meny") page
       | otherwise = do
         log $ "No test for category type " <> Models.toString c.type <> " (" <> show c.label <> ")"

--- a/apps/mosaico/test/Search.purs
+++ b/apps/mosaico/test/Search.purs
@@ -19,7 +19,7 @@ searchField :: Chrome.Selector
 searchField = Chrome.Selector ".mosaico-search input"
 
 pageTitle :: Chrome.Selector
-pageTitle = Chrome.Selector ".mosaico--article-list > h1"
+pageTitle = Chrome.Selector ".mosaico--article-list > h2"
 
 testSearchNavigation :: Test
 testSearchNavigation page = do

--- a/less/mosaico/article-list.less
+++ b/less/mosaico/article-list.less
@@ -6,23 +6,6 @@
     justify-self: center;
   }
 
-  h1 {
-    grid-area: main;
-    font: bold 1.75rem/1 "Roboto", sans-serif;
-    display: inline-block;
-    margin-bottom: 30px;
-    border-bottom: solid 3px #ccc;
-    #HBL & {
-      border-color: @hbl-orange;
-    }
-    #ON & {
-      border-color: @on-blue;
-    }
-    #VN & {
-      border-color: @vn-red;
-    }
-  }
-
   .list-article-image {
     img {
       width: 100%;

--- a/less/mosaico/components/epaper.less
+++ b/less/mosaico/components/epaper.less
@@ -138,7 +138,7 @@
     header {
       padding: 10px 0;
       text-align: center;
-      h1 {
+      h2 {
         font-size: 1.2rem;
         font-weight: 700;
         display: flex;


### PR DESCRIPTION
This makes the following changes:
- every page has exactly one `<h1>` element. Usually article title, but defaults to a sr-only title in the header with the paper name if there are no other options.
- All headings follow consistent numbering, so you won't go from h3 to h6.