### PR TITLE
Hide all widget titles

### DIFF
--- a/less/mosaico/aptoma.less
+++ b/less/mosaico/aptoma.less
@@ -11,7 +11,7 @@
 @media (min-width: 768px) and (max-width: 999px) {
   // Show senast publicerat and andra läser at the bottom on this screen size,
   // not at the top
-  .front>.dre-section {
+  .front > .dre-section {
     display: flex;
     flex-direction: column;
   }
@@ -40,4 +40,11 @@
 .dre-item--feature-advertorial .dre-item__header {
   // there's a pretty specific selector setting this to 400 in Aptoma's CSS...
   font-weight: 700 !important;
+}
+
+[data-placeholder="widget"] > .dre-item__title {
+  visibility: hidden;
+  > * {
+    visibility: visible;
+  }
 }


### PR DESCRIPTION
When loading (or when browsing without Javascript), the widget titles (eg. 'Box Ad 1 DESKTOP') will briefly flash before they get  replaced with whatever they are supposed to contain.

![2022-07-12-112432_1732x460_scrot](https://user-images.githubusercontent.com/91122811/178445358-473a9574-b9c3-4e5c-b073-01e0165b609f.png)
