### PR TITLE
New per-app ad slots for programmatic ads - wip

### DIFF
--- a/apps/app-article-server/src/browser/components/article-content.js
+++ b/apps/app-article-server/src/browser/components/article-content.js
@@ -50,9 +50,9 @@ class Content extends Component {
 
   renderAd(block, key) {
     if (block.ad === "MOBMITT" && this.props.articleType !== "Advertorial") {
-      return <p key={key} className="ksf-app-ad" id="MOBMITT"></p>;
+      return <p key={key} className="ksf-app-ad" id={this.state.paper + "/" + this.state.paper + "_" + "mobmitt"}></p>;
     } else if (this.props.articleType !== "Advertorial") {
-      return <p key={key} className="ksf-app-ad" id="DIGIHELMOB"></p>;
+      return <p key={key} className="ksf-app-ad" id={this.state.paper + "/" + this.state.paper + "_" + "digihelmob"}></p>;
     } else {
       console.log("No ads shown in advertorials.");
     }
@@ -225,13 +225,13 @@ class Content extends Component {
           id={"content"}
           style={_.merge({ wordWrap: "break-word" })}
         >
-          {this.props.articleType === "Advertorial" || <div className="ksf-app-ad" id="MOBPARAD"></div>}
+          {this.props.articleType === "Advertorial" || <div className="ksf-app-ad" id={this.state.paper + "/" + this.state.paper + "_" + "mobparad"}></div>}
           {this.props.body != null
             ? this.props.body.map((block, key) => {
                 return this.conditionalRendering(block, key);
               })
             : ""}
-          {this.props.articleType === "Advertorial" || <div className="ksf-app-ad" id="MOBBOX1"></div>}
+          {this.props.articleType === "Advertorial" || <div className="ksf-app-ad" id={this.state.paper + "/" + this.state.paper + "_" + "mobbox1"}></div>}
         </div>
       </div>
     );

--- a/apps/app-article-server/src/browser/index.css
+++ b/apps/app-article-server/src/browser/index.css
@@ -203,10 +203,18 @@ h6 {
 }
 
 /*Ads*/
-#MOBPARAD,
-#MOBMITT,
-#DIGIHELMOB,
-#MOBBOX1 {
+#hbl\/hbl_mobparad,
+#hbl\/hbl_mobmitt,
+#hbl\/hbl_digihelmob,
+#hbl\/hbl_mobbox1,
+#on\/on_mobparad,
+#on\/on_mobmitt,
+#on\/on_digihelmob,
+#on\/on_mobbox1,
+#vn\/vn_mobparad,
+#vn\/vn_mobmitt,
+#vn\/vn_digihelmob,
+#vn\/vn_mobbox1 {
   text-align: center;
   margin-bottom: 20px;
   overflow: hidden;

--- a/apps/app-article-server/src/browser/index.html
+++ b/apps/app-article-server/src/browser/index.html
@@ -115,6 +115,7 @@
 
       window.googletag.cmd.push(function () {
         // Testing by key-value - are we abandoning key-values now?
+        // #TODO - Remove this key-value targeting before merging code
         googletag.pubads().setTargeting("Test", "mosaico_test");
         // Production by key-value
         // googletag.pubads().setTargeting("newspaper", appToTarget);

--- a/apps/app-article-server/src/browser/index.html
+++ b/apps/app-article-server/src/browser/index.html
@@ -54,7 +54,7 @@
         return new URLSearchParams(window.location.search);
       };
 
-      const getBrandValueParam = () => {
+      const getPaper = () => {
         let urlParams = getUrlParam();
         if (urlParams.has("paper")) {
           return urlParams.get("paper");
@@ -62,83 +62,89 @@
         return "hbl";
       };
 
-      const brandValueName = getBrandValueParam();
-      let appToTarget = "";
+      const paper = getPaper();
 
-      if (brandValueName == "on") {
-        appToTarget = "appON";
-      } else if (brandValueName == "vn") {
-        appToTarget = "appVN";
-      } else {
-        appToTarget = "appHBL";
+      window.buildGamAndTargetId = function(name) {
+        return paper + "/" + paper + "_" + name;
       }
 
+      window.adSlots = [
+        {
+          gamAndTargetId: window.buildGamAndTargetId("mobparad"),
+          sizes: [
+            [300, 100],
+            [300, 250],
+            [300, 300],
+            [300, 431],
+            [300, 600],
+          ],
+        },
+        {
+          gamAndTargetId: window.buildGamAndTargetId("mobmitt"),
+          sizes: [
+            [300, 100],
+            [300, 250],
+            [300, 300],
+            [300, 431],
+            [300, 600],
+          ],
+        },
+        {
+          gamAndTargetId: window.buildGamAndTargetId("digihelmob"),
+          sizes: [
+            [300, 100],
+            [300, 250],
+            [300, 300],
+            [300, 431],
+            [300, 600],
+          ],
+        },
+        {
+          gamAndTargetId: window.buildGamAndTargetId("mobbox1"),
+          sizes: [
+            [300, 100],
+            [300, 250],
+            [300, 300],
+            [300, 431],
+            [300, 600],
+          ],
+        },
+      ];
+
       window.googletag = window.googletag || { cmd: [] };
+
       window.googletag.cmd.push(function () {
-        googletag
-          .defineSlot(
-            "/21664538223/MOBPARAD",
-            [
-              [300, 100],
-              [300, 250],
-              [300, 300],
-              [300, 431],
-              [300, 600],
-            ],
-            "MOBPARAD"
-          )
-          .addService(googletag.pubads());
+        // Testing by key-value - are we abandoning key-values now?
+        googletag.pubads().setTargeting("Test", "mosaico_test");
+        // Production by key-value
+        // googletag.pubads().setTargeting("newspaper", appToTarget);
 
-        googletag
-          .defineSlot(
-            "/21664538223/MOBMITT",
-            [
-              [300, 100],
-              [300, 250],
-              [300, 300],
-              [300, 431],
-              [300, 600],
-            ],
-            "MOBMITT"
-          )
-          .addService(googletag.pubads());
+        const networkCode = "/21664538223/";
 
-        googletag
-          .defineSlot(
-            "/21664538223/DIGIHELMOB",
-            [
-              [300, 100],
-              [300, 250],
-              [300, 300],
-              [300, 431],
-              [300, 600],
-            ],
-            "DIGIHELMOB"
-          )
-          .addService(googletag.pubads());
+        const slots = window.adSlots;
+        slots.map((slot) => {
+          googletag
+            .defineSlot(networkCode + slot.gamAndTargetId, slot.sizes, slot.gamAndTargetId)
+            .addService(googletag.pubads());
+        });
 
-        googletag
-          .defineSlot(
-            "/21664538223/MOBBOX1",
-            [
-              [300, 100],
-              [300, 250],
-              [300, 300],
-              [300, 431],
-              [300, 600],
-            ],
-            "MOBBOX1"
-          )
-          .addService(googletag.pubads());
+        window.definedSlots = googletag
+          .pubads()
+          .getSlots()
+          .map((s) => s.getSlotElementId());
 
         googletag.pubads().enableSingleRequest();
         googletag.pubads().collapseEmptyDivs();
         googletag.enableServices();
 
-        // Testing
-        // googletag.pubads().setTargeting("Test", "mosaico_test");
-        // Production
-        googletag.pubads().setTargeting("newspaper", appToTarget);
+        // #TODO Get this working again - commented out because causing exceptions
+        // Is "populated" being used anywhere? Maybe by Google Ad Manager?
+        // googletag.pubads().addEventListener("slotRenderEnded", (event) => {
+        //   if (!event.isEmpty) {
+        //     let elementId = event.slot.getSlotElementId();
+        //     document.querySelector("#" + elementId).classList.add("populated");
+        //   }
+        // });
       });
     </script>
     <!--End Google Ad-->
@@ -169,8 +175,8 @@
     <script src="./index.js"></script>
     <script>
       googletag.cmd.push(function () {
-        googletag.display("MOBPARAD");
-        googletag.display("MOBBOX1");
+        googletag.display(window.buildGamAndTargetId("mobparad"));
+        googletag.display(window.buildGamAndTargetId("mobbox1"));
       });
     </script>
   </body>


### PR DESCRIPTION
This code is currently using the same code for the GAM ad unit and the target id (`gamAndTargetId` in the code), because I got this working. So the `gamAndTargetId` will be eg

```
on/on_mobparad
vn/vn_mobparad
hbl/hbl_mobparad
...
```
I have tried switching the target id to be consistent with Mosaico (details here: https://docs.google.com/spreadsheets/d/1gWwZMC3PUNZ_UeesnVOpkgjhYoDsE6HKlsW00FMKOOQ/edit#gid=1632593384) but couldn't then get the ads to show up.

There are also a couple of #TODOS/comments in the code which need reviewing and/or changing before we merge this branch.