### PR TITLE
Fix scroll bug on older browsers

### DIFF
--- a/apps/app-article-server/src/browser/index.css
+++ b/apps/app-article-server/src/browser/index.css
@@ -80,7 +80,7 @@ h6 {
 
 .article {
   padding-bottom: 20px;
-  overflow-x: clip;
+  overflow-x: hidden;
 }
 
 .title {


### PR DESCRIPTION
A small bug was happening on older browser. Was using an unsupported value for overflow.