### PR TITLE
Enable ads to be targeted at apps only

### DIFF
--- a/apps/app-article-server/src/browser/index.html
+++ b/apps/app-article-server/src/browser/index.html
@@ -114,8 +114,7 @@
       window.googletag = window.googletag || { cmd: [] };
 
       window.googletag.cmd.push(function () {
-        // Testing by key-value - Keep commented out for future testing
-        // googletag.pubads().setTargeting("Test", "mosaico_test");
+        googletag.pubads().setTargeting("sites-or-apps", "apps-only");
         const networkCode = "/21664538223/";
 
         const slots = window.adSlots;


### PR DESCRIPTION
A key-value pair has been added to Google Ad Manager so some ads can just to targeted at the apps and not the sites. This code adds that key-value pair.