### PR TITLE
Tweak to ad position logic

### DIFF
--- a/apps/app-article-server/src/browser/index.js
+++ b/apps/app-article-server/src/browser/index.js
@@ -44,7 +44,8 @@ if (window.article) {
 
   if (ad1Position && ad2Position) {
     body.splice(ad1Position, 0, { ad: "MOBMITT" });
-    body.splice(ad2Position, 0, { ad: "DIGIHELMOB" });
+    // +1 needed because inserted ad1 changes positioning after it
+    body.splice(ad2Position+1, 0, { ad: "DIGIHELMOB" });
   } else if (ad1Position) {
     body.splice(ad1Position, 0, { ad: "MOBMITT" });
   }

--- a/apps/app-article-server/src/browser/index.js
+++ b/apps/app-article-server/src/browser/index.js
@@ -14,8 +14,8 @@ if (window.article) {
   var ad2RoughPosition;
 
   if (elemsCount > 15) {
-    ad1RoughPosition = Math.floor(elemsCount / 3);
-    ad2RoughPosition = Math.floor(elemsCount / 1.5);
+    ad1RoughPosition = Math.floor(elemsCount / 3.3);
+    ad2RoughPosition = Math.floor(elemsCount / 1.6);
   } else if (elemsCount > 6) {
     ad1RoughPosition = Math.floor(elemsCount / 2);
   }


### PR DESCRIPTION
https://trello.com/c/cpmbDKe6/1408-improve-placement-of-ads-in-app-article

Tweak to ad position logic to make it less likely two ads will appear in a row in the middle of an article. Currently, each ad slots into a space in between two "html" elements, but they may end up right next to each other if the first ad cannot find a suitable slot early enough. This change makes the first ad start looking for a suitable slot earlier on in the article.