### PR TITLE
Improve search

### DIFF
--- a/packages/components/src/InputField/InputField.purs
+++ b/packages/components/src/InputField/InputField.purs
@@ -35,12 +35,14 @@ type Props =
   , disabled        :: Boolean
   , extraClass      :: String
   , autoComplete    :: String
+  , autoFocus       :: Boolean
   )
 
 type DefaultProps =
   ( disabled        :: Boolean
   , extraClass      :: String
   , autoComplete    :: String
+  , autoFocus       :: Boolean
   )
 
 type State =
@@ -66,6 +68,7 @@ inputField userProps = React.make component
       { disabled: false
       , extraClass: ""
       , autoComplete: ""
+      , autoFocus: false
       }
 
     didMount { props, setState } = when (isJust props.value) $

--- a/packages/components/src/InputField/InputField.purs
+++ b/packages/components/src/InputField/InputField.purs
@@ -104,6 +104,7 @@ render self@{ props, state } =
                 else mempty
             , disabled: props.disabled
             , autoComplete: if props.autoComplete == "" then unsafeCoerce Nullable.null else props.autoComplete
+            , autoFocus: props.autoFocus
             }
         ] `snoc` foldMap errorMessage props.validationError
     }


### PR DESCRIPTION
Add `autoFocus` prop to the **inputField** module. Allows to set a field in focus when page renders.