### PR TITLE
fix out-of-sync keys caused by inserted ads

### DIFF
--- a/apps/app-article-server/src/browser/components/article-content.js
+++ b/apps/app-article-server/src/browser/components/article-content.js
@@ -11,8 +11,9 @@ class Content extends Component {
     };
   }
 
-  conditionalRendering(block, key) {
-    let blockType = Object.keys(block)[0].toLowerCase() || null;
+  conditionalRendering(block) {
+    const blockType = Object.keys(block)[0].toLowerCase() || null;
+    const key = block.key;
     if (blockType != null) {
       if (blockType === "ad") {
         return this.renderAd(block, key);
@@ -211,8 +212,8 @@ class Content extends Component {
           <div
             className={`expand ${this.props.darkModeEnabled ? "darkMode" : ""}`}
             id={"expandFactBox-" + key}
-            onClick={(ev) => {
-              this.expandFactBox(ev);
+            onClick={() => {
+              this.expandFactBox(key);
             }}
           >
             <div className={`expandOpacity ${this.props.darkModeEnabled ? "darkMode" : ""}`} id={"expandOpacity"}></div>
@@ -269,8 +270,7 @@ class Content extends Component {
     return $.html()
   }
 
-  expandFactBox(ev) {
-    const key = /\d+/.exec(ev.currentTarget.id)[0];
+  expandFactBox(key) {
     document.getElementById("genericBox-" + key).style.height = "auto";
     document.getElementById("expandFactBox-" + key).style.display = "none";
     document.getElementById("expandOpacity").style.display = "none";

--- a/apps/app-article-server/src/browser/components/article-content.js
+++ b/apps/app-article-server/src/browser/components/article-content.js
@@ -327,8 +327,8 @@ class Content extends Component {
         >
           {this.renderAdOutsideMainBlock("mobparad")}
           {this.props.body != null
-            ? this.props.body.map((block, key) => {
-                return this.conditionalRendering(block, key);
+            ? this.props.body.map((block) => {
+                return this.conditionalRendering(block);
               })
             : ""}
           <div className={"row"}>

--- a/apps/app-article-server/src/browser/index.js
+++ b/apps/app-article-server/src/browser/index.js
@@ -6,57 +6,13 @@ import "./index.css";
 import Article from "./components/article";
 import * as serviceWorker from "./serviceWorker";
 if (window.article) {
-  var body = [...window.article.body];
-  var bodyElems = body.map((elem) => Object.keys(elem));
-  var elemsCount = bodyElems.length;
-
-  var ad1RoughPosition;
-  var ad2RoughPosition;
-
-  if (elemsCount > 15) {
-    ad1RoughPosition = Math.floor(elemsCount / 3.3);
-    ad2RoughPosition = Math.floor(elemsCount / 1.6);
-  } else if (elemsCount > 6) {
-    ad1RoughPosition = Math.floor(elemsCount / 2);
-  }
-
-  function findExactPositionForAd(roughPosition) {
-    var position;
-    for (let i = roughPosition; i < elemsCount; i++) {
-      if (canAdGoHere(i)) {
-        position = i;
-        break;
-      }
-    }
-    return position;
-  }
-
-  function canAdGoHere(i) {
-    if (bodyElems[i - 1] == "html" && bodyElems[i] == "html") {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  var ad1Position = findExactPositionForAd(ad1RoughPosition);
-  var ad2Position = findExactPositionForAd(ad2RoughPosition);
-
-  if (ad1Position && ad2Position) {
-    body.splice(ad1Position, 0, { ad: "MOBMITT" });
-    // +1 needed because inserted ad1 changes positioning after it
-    body.splice(ad2Position+1, 0, { ad: "DIGIHELMOB" });
-  } else if (ad1Position) {
-    body.splice(ad1Position, 0, { ad: "MOBMITT" });
-  }
-
   rehydrateMarks().then(() => {
     ReactDOM.hydrate(
       <Article
         articleType={window.article.articleType}
         articleTypeDetails={window.article.articleTypeDetails}
         authors={window.article.authors}
-        body={body}
+        body={window.article.body}
         darkModeEnabled={window.article.darkModeEnabled}
         fontSize={window.article.fontSize}
         isPreview={window.article.isPreview}

--- a/apps/app-article-server/src/server/index.js
+++ b/apps/app-article-server/src/server/index.js
@@ -11,6 +11,7 @@ const UUID = require("uuid");
 import generateHtml from "./generateHtml";
 import Article from "../browser/components/article";
 import ErrorPage from "../browser/components/error";
+import { v4 as uuidv4 } from 'uuid';
 
 app.use("/dist", express.static(`${__dirname}/../client`));
 
@@ -81,6 +82,15 @@ async function renderArticle(articleId, res, authHeaders, queryParams, queryStri
 	  isPreviewArticle = true;
 	}
 	const user = _.get(responses[1], "data");
+
+	const articleBody = article.body.map(block => {
+		return {
+			...block,
+			key: uuidv4(),
+		}
+	})
+
+	article = {...article, body: articleBody};
 
 	const articleJSX = (
 	  <Article

--- a/apps/app-article-server/src/server/index.js
+++ b/apps/app-article-server/src/server/index.js
@@ -9,6 +9,7 @@ const https = require("https");
 const UUID = require("uuid");
 
 import generateHtml from "./generateHtml";
+import insertAds from "./insertAds";
 import Article from "../browser/components/article";
 import ErrorPage from "../browser/components/error";
 import { v4 as uuidv4 } from 'uuid';
@@ -83,7 +84,9 @@ async function renderArticle(articleId, res, authHeaders, queryParams, queryStri
 	}
 	const user = _.get(responses[1], "data");
 
-	const articleBody = article.body.map(block => {
+	const articleBodyWithAds = insertAds(article.body);
+
+	const articleBody = articleBodyWithAds.map(block => {
 		return {
 			...block,
 			key: uuidv4(),

--- a/apps/app-article-server/src/server/insertAds.js
+++ b/apps/app-article-server/src/server/insertAds.js
@@ -1,0 +1,47 @@
+export default function insertAds(articleBody) {
+  var bodyElems = articleBody.map((elem) => Object.keys(elem));
+  var elemsCount = bodyElems.length;
+
+  var ad1RoughPosition;
+  var ad2RoughPosition;
+
+  if (elemsCount > 15) {
+    ad1RoughPosition = Math.floor(elemsCount / 3.3);
+    ad2RoughPosition = Math.floor(elemsCount / 1.6);
+  } else if (elemsCount > 6) {
+    ad1RoughPosition = Math.floor(elemsCount / 2);
+  }
+
+  function findExactPositionForAd(roughPosition) {
+    var position;
+    for (let i = roughPosition; i < elemsCount; i++) {
+      if (canAdGoHere(i)) {
+        position = i;
+        break;
+      }
+    }
+    return position;
+  }
+
+  function canAdGoHere(i) {
+    if (bodyElems[i - 1] == "html" && bodyElems[i] == "html") {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  var ad1Position = findExactPositionForAd(ad1RoughPosition);
+  var ad2Position = findExactPositionForAd(ad2RoughPosition);
+
+  if (ad1Position && ad2Position) {
+    // body = [{ ad: "MOBMITT"}, ...body];
+    articleBody.splice(ad1Position, 0, { ad: "MOBMITT" });
+    // +1 needed because inserted ad1 changes positioning after it
+    articleBody.splice(ad2Position+1, 0, { ad: "DIGIHELMOB" });
+  } else if (ad1Position) {
+    articleBody.splice(ad1Position, 0, { ad: "MOBMITT" });
+  }
+
+  return articleBody;
+}


### PR DESCRIPTION
https://trello.com/c/Cg5scatM/1303-app-article-servers-frontend-rendering-doesnt-match-backends-rendering

Tested on the factbox in this article: http://localhost:8080/article/44f345b5-eb92-4e60-a884-26396cd3d831?paper=test  (test parameter makes test ads appear)

We've been using the array index to create keys for article items, but this has led to a mismatch between keys created before and after ads have been inserted into the article. So instead, as soon as the article has been fetched, the ad slots are inserted and a uuid-generated key is then created for each article item. The keys then don't change on render.

The factbox in the test article should open up, if the keys are in sync.