### PR TITLE
Improve app article loading

### DIFF
--- a/apps/app-article-server/package.json
+++ b/apps/app-article-server/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^17.0.2",
     "react-image-lightbox": "^5.1.1",
     "react-imported-component": "^6.4.1",
+    "react-lazy-load-image-component": "^1.5.6",
     "uuid": "^8.3.2"
   },
   "scripts": {

--- a/apps/app-article-server/src/browser/components/article-content.js
+++ b/apps/app-article-server/src/browser/components/article-content.js
@@ -167,15 +167,6 @@ class Content extends Component {
             this.props.showHighResolutionImage(block.image.url, caption + " " + appendBylineLabel + " " + byline)
           }
         />
-{/*         <img
-          className={"articleImage"}
-          width="100%"
-          src={block.image.url}
-          alt=""
-          onClick={() =>
-            this.props.showHighResolutionImage(block.image.url, caption + " " + appendBylineLabel + " " + byline)
-          }
-        /> */}
         <p
           dangerouslySetInnerHTML={{
             __html: caption + " " + appendBylineLabel + " " + byline,

--- a/apps/app-article-server/src/browser/components/article-content.js
+++ b/apps/app-article-server/src/browser/components/article-content.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 const _ = require("lodash");
 import * as cheerio from 'cheerio';
 import PremiumBox from "./premium";
+import { LazyLoadImage } from "react-lazy-load-image-component";
+import 'react-lazy-load-image-component/src/effects/opacity.css';
 
 class Content extends Component {
   constructor(props) {
@@ -154,7 +156,18 @@ class Content extends Component {
     let byline = block.image.byline === null ? "" : block.image.byline;
     return (
       <div className={"image"} key={key}>
-        <img
+        <LazyLoadImage 
+          className={"articleImage"}
+          width="100%"
+          src={block.image.url}
+          threshold="200"
+          effect="opacity"
+          alt=""
+          onClick={() =>
+            this.props.showHighResolutionImage(block.image.url, caption + " " + appendBylineLabel + " " + byline)
+          }
+        />
+{/*         <img
           className={"articleImage"}
           width="100%"
           src={block.image.url}
@@ -162,7 +175,7 @@ class Content extends Component {
           onClick={() =>
             this.props.showHighResolutionImage(block.image.url, caption + " " + appendBylineLabel + " " + byline)
           }
-        />
+        /> */}
         <p
           dangerouslySetInnerHTML={{
             __html: caption + " " + appendBylineLabel + " " + byline,

--- a/apps/app-article-server/src/browser/components/article.js
+++ b/apps/app-article-server/src/browser/components/article.js
@@ -4,7 +4,6 @@ import Header from "./header";
 import Additional from "./article-additional";
 import ArticleDetails from "./article-details";
 import Content from "./article-content";
-// import MostReadArticles from "./most-read-articles";
 import Footer from "./footer";
 import RelatedArticles from "./related-articles";
 import Lightbox from "react-image-lightbox";

--- a/apps/app-article-server/src/browser/components/article.js
+++ b/apps/app-article-server/src/browser/components/article.js
@@ -1,14 +1,16 @@
-import React, { Component } from "react";
+import React, { Component, Suspense } from "react";
 import hblDefaultImage from "../assets/images/hbl-fallback-img.png";
 import Header from "./header";
 import Additional from "./article-additional";
 import ArticleDetails from "./article-details";
 import Content from "./article-content";
-import MostReadArticles from "./most-read-articles";
+// import MostReadArticles from "./most-read-articles";
 import Footer from "./footer";
 import RelatedArticles from "./related-articles";
 import Lightbox from "react-image-lightbox";
 import "react-image-lightbox/style.css";
+
+const MostReadArticles = React.lazy(() => import('./most-read-articles'))
 
 const axios = require("axios");
 var _ = require("lodash");
@@ -132,12 +134,14 @@ class Article extends Component {
               ""
             )}
             {this.state.mostReadArticles.length > 0 ? (
-              <MostReadArticles
-                mostReadArticles={this.state.mostReadArticles}
-                queryString={this.props.queryString}
-                darkModeEnabled={this.props.darkModeEnabled}
-                paper={this.props.paper}
-              />
+              <Suspense fallback={<div>Laddar ...</div>}>
+                <MostReadArticles
+                  mostReadArticles={this.state.mostReadArticles}
+                  queryString={this.props.queryString}
+                  darkModeEnabled={this.props.darkModeEnabled}
+                  paper={this.props.paper}
+                />
+              </Suspense>
             ) : (
               ""
             )}

--- a/apps/app-article-server/src/browser/components/mobile-article-list.js
+++ b/apps/app-article-server/src/browser/components/mobile-article-list.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { LazyLoadImage, trackWindowScroll } from "react-lazy-load-image-component";
 import hblDefaultImage from "../assets/images/hbl-fallback-img.png";
 const _ = require("lodash");
-import 'react-lazy-load-image-component/src/effects/blur.css';
 
 const isArray = (value) => {
   return value && typeof value === "object" && value.constructor === Array;
@@ -75,7 +74,7 @@ const MobileList = (props) => {
                       className="listImage"
                       scrollPosition={props.scrollPosition}
                       placeholderSrc={hblDefaultImage}
-                      effect="blur"
+                      effect="opacity"
                     />
 
 {/*                     <img

--- a/apps/app-article-server/src/browser/components/mobile-article-list.js
+++ b/apps/app-article-server/src/browser/components/mobile-article-list.js
@@ -76,15 +76,6 @@ const MobileList = (props) => {
                       placeholderSrc={hblDefaultImage}
                       effect="opacity"
                     />
-
-{/*                     <img
-                      className="listImage"
-                      src={item.listImage.url.includes("imengine")
-                          ? item.listImage.url + "&function=hardcrop&width=360&height=200&q=65"
-                          : item.listImage.tinyThumb
-                          }
-                      alt=""
-                    /> */}
                     </>
                   )}
                 </div>

--- a/apps/app-article-server/src/browser/components/mobile-article-list.js
+++ b/apps/app-article-server/src/browser/components/mobile-article-list.js
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
+import { LazyLoadImage, trackWindowScroll } from "react-lazy-load-image-component";
 import hblDefaultImage from "../assets/images/hbl-fallback-img.png";
 const _ = require("lodash");
+import 'react-lazy-load-image-component/src/effects/blur.css';
 
 const isArray = (value) => {
   return value && typeof value === "object" && value.constructor === Array;
@@ -64,14 +66,27 @@ const MobileList = (props) => {
                   {item.listImage === null ? (
                     <img className="listImage" src={hblDefaultImage} alt="" />
                   ) : (
-                    <img
+                    <>
+                    <LazyLoadImage
+                      src={item.listImage.url.includes("imengine")
+                      ? item.listImage.url + "&function=hardcrop&width=360&height=200&q=65"
+                      : item.listImage.tinyThumb
+                      }
+                      className="listImage"
+                      scrollPosition={props.scrollPosition}
+                      placeholderSrc={hblDefaultImage}
+                      effect="blur"
+                    />
+
+{/*                     <img
                       className="listImage"
                       src={item.listImage.url.includes("imengine")
                           ? item.listImage.url + "&function=hardcrop&width=360&height=200&q=65"
                           : item.listImage.tinyThumb
                           }
                       alt=""
-                    />
+                    /> */}
+                    </>
                   )}
                 </div>
               </a>
@@ -85,4 +100,4 @@ const MobileList = (props) => {
   }
 };
 
-export default MobileList;
+export default trackWindowScroll(MobileList);

--- a/apps/app-article-server/src/browser/components/mobile-article-list.js
+++ b/apps/app-article-server/src/browser/components/mobile-article-list.js
@@ -68,8 +68,8 @@ const MobileList = (props) => {
                     <>
                     <LazyLoadImage
                       src={item.listImage.url.includes("imengine")
-                      ? item.listImage.url + "&function=hardcrop&width=360&height=200&q=65"
-                      : item.listImage.tinyThumb
+                        ? item.listImage.url + "&function=hardcrop&width=360&height=200&q=65"
+                        : item.listImage.tinyThumb
                       }
                       className="listImage"
                       scrollPosition={props.scrollPosition}

--- a/apps/app-article-server/src/browser/index.css
+++ b/apps/app-article-server/src/browser/index.css
@@ -1,27 +1,32 @@
 @font-face {
   font-family: "Roboto";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Regular-webfont.woff2") format("woff2");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Regular-webfont.woff2") format("woff2"),
+    url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Regular.ttf") format("truetype");
 }
 
 @font-face {
   font-family: "Roboto Bold";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Bold-webfont.woff2") format("woff2");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Bold-webfont.woff2") format("woff2"),
+    url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Bold.ttf") format("truetype");
 }
 
 @font-face {
   font-family: "Duplex Sans Bold";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Sans-Web-Bold.woff2") format("woff2");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Sans-Web-Bold.woff2") format("woff2"),
+    url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Sans-Web-Bold.otf") format("opentype");
 }
 
 @font-face {
   font-family: "Duplex Sans Light";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Sans-Web-Light.woff2") format("woff2");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Sans-Web-Light.woff2") format("woff2"),
+    url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Sans-Light.otf") format("opentype");
   font-weight: 300;
 }
 
 @font-face {
   font-family: "Duplex Serif Bold";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Serif-Web-Bold.woff2") format("woff2");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Serif-Web-Bold.woff2") format("woff2"),
+    url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Serif-Bold.otf") format("opentype");
 }
 
 :root {

--- a/apps/app-article-server/src/browser/index.css
+++ b/apps/app-article-server/src/browser/index.css
@@ -618,6 +618,7 @@ h6 {
   margin-top: 3px;
   margin-bottom: 10px;
   text-align: right;
+  min-height: 150px;
 }
 
 .listImageContainer {

--- a/apps/app-article-server/src/browser/index.css
+++ b/apps/app-article-server/src/browser/index.css
@@ -1,21 +1,27 @@
 @font-face {
   font-family: "Roboto";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Regular.ttf");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Regular-webfont.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Roboto Bold";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Bold.ttf");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Roboto-Bold-webfont.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Duplex Sans Bold";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex%20Sans-Bold.otf");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Sans-Web-Bold.woff2") format("woff2");
+}
+
+@font-face {
+  font-family: "Duplex Sans Light";
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Sans-Web-Light.woff2") format("woff2");
+  font-weight: 300;
 }
 
 @font-face {
   font-family: "Duplex Serif Bold";
-  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Serif-Bold.otf");
+  src: url("https://cdn.ksfmedia.fi/assets/fonts/Duplex-Serif-Web-Bold.woff2") format("woff2");
 }
 
 :root {
@@ -91,7 +97,7 @@ h6 {
 .title {
   color: #333;
   line-height: 30px;
-  font-family: "Duplex Serif Bold", sans-serif;
+  font-family: "Duplex Serif Bold", serif;
   font-size: 2rem;
   letter-spacing: 0px;
 }
@@ -115,7 +121,7 @@ h6 {
 }
 
 .preamble {
-  font: 400 1.4rem/1.2 Duplex Sans,sans-serif;
+  font: 300 1.4rem/1.2 "Duplex Sans Light",sans-serif;
 }
 
 .article .content h2,
@@ -433,8 +439,7 @@ h6 {
 
 .articleTag {
   text-transform: uppercase;
-  font-family: 'Roboto Bold', sans-serif;
-  font-weight: bold;
+  font-family: "Roboto Bold", sans-serif;
   font-size: 14px;
 }
 
@@ -577,7 +582,7 @@ h6 {
 }
 
 .relatedArticles .articleItem {
-  font-family: "Duplex Serif Bold", sans-serif;
+  font-family: "Duplex Serif Bold", serif;
   color: #323232;
 }
 

--- a/apps/app-article-server/src/browser/index.html
+++ b/apps/app-article-server/src/browser/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
     <link rel="stylesheet" type="text/css" href="../../../../less/app-article.less" />
-    <link rel="stylesheet" type="text/css" href="./index.css" />
     <link
       rel="stylesheet"
       type="text/css"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8853,6 +8853,14 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-lazy-load-image-component@^1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.5.6.tgz#a4b84257be21b1825680b4e158d167c08aeda5ff"
+  integrity sha512-M0jeJtOlTHgThOfgYM9krSqYbR6ShxROy/KVankwbw9/amPKG1t5GSGN1sei6Cyu8+QJVuyAUvQ+LFtCVTTlKw==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"


### PR DESCRIPTION
What this does:
• Uses React.lazy for the most read list component (don't think this do much when we return the page from the server)
• Lazy loads all images except main header image. Uses react-lazy-load-component for this.
• Use smaller file formats for fonts, woff2 seems to have been supported for quite a while now.
• We seemed to be loading some css twice. Stopped doing that.