### PR TITLE
Make Sentry transactionSamplingRate configurable

### DIFF
--- a/packages/components/src/Sentry.js
+++ b/packages/components/src/Sentry.js
@@ -7,14 +7,14 @@
 
    https://docs.sentry.io/platforms/javascript/
  */
-export function initSentry_(sentryDsn) {
+export function initSentry_(sentryDsn, tSampleRate) {
   var Sentry = require("@sentry/browser");
   var Tracing = require("@sentry/tracing");
   if (sentryDsn && sentryDsn.length > 1) {
     Sentry.init({
       dsn: sentryDsn,
       integrations: [new Tracing.BrowserTracing()],
-      tracesSampleRate: 0.03,
+      tracesSampleRate: tSampleRate,
       beforeSend(event, hint) {
         const error = hint.originalException;
         // Ignore an error caused by Instagram's browser

--- a/packages/components/src/Sentry.purs
+++ b/packages/components/src/Sentry.purs
@@ -3,7 +3,7 @@ module KSF.Sentry where
 import Prelude
 
 import Data.Generic.Rep (class Generic)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Nullable (Nullable, toNullable)
 import Data.Show.Generic (genericShow)
 import Data.String (toLower)
@@ -11,11 +11,12 @@ import Data.UUID as UUID
 import Effect (Effect)
 import Effect.Class.Console as Console
 import Effect.Exception (Error)
-import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3, EffectFn4, runEffectFn1, runEffectFn2, runEffectFn3, runEffectFn4)
+import Effect.Uncurried (EffectFn2, EffectFn3, EffectFn4, runEffectFn2, runEffectFn3, runEffectFn4)
 import KSF.User as User
 import KSF.User.Cusno (Cusno(..))
 
-foreign import initSentry_       :: EffectFn1 String Sentry
+
+foreign import initSentry_       :: EffectFn2 String Number Sentry
 foreign import captureMessage_   :: EffectFn4 Sentry String String String Unit
 foreign import captureException_ :: EffectFn3 Sentry String Error Unit
 foreign import setTag_           :: EffectFn3 Sentry String String Unit
@@ -49,9 +50,17 @@ emptyLogger =
   , setTag: \_ _ -> pure unit
   }
 
+-- Sentry logger using default sapmpling rate
 mkLogger :: String -> Maybe User.User -> String -> Effect Logger
-mkLogger sentryDsn maybeUser appNameTag = do
-  sentry <- runEffectFn1 initSentry_ sentryDsn
+mkLogger sentryDsn = mkLogger' sentryDsn Nothing
+
+-- Sentry logger with a custom sampling rate
+mkLoggerWithSR :: String -> Number -> Maybe User.User -> String -> Effect Logger
+mkLoggerWithSR sentryDsn samplingRate = mkLogger' sentryDsn (Just samplingRate)
+
+mkLogger' :: String -> Maybe Number -> Maybe User.User -> String -> Effect Logger
+mkLogger' sentryDsn maybeSR maybeUser appNameTag = do
+  sentry <- runEffectFn2 initSentry_ sentryDsn $ fromMaybe 0.8 maybeSR
   sessionId <- UUID.genUUID
   -- Set sessionId to Sentry
   -- This is to batch requests together if no User if ever set.


### PR DESCRIPTION
This will let apps define their own transaction sampling rate for Sentry as the rate required by mosaico is quite low (0.03)