### PR TITLE
No initial scroll

### DIFF
--- a/packages/vetrina/src/Vetrina/Vetrina.js
+++ b/packages/vetrina/src/Vetrina/Vetrina.js
@@ -3,8 +3,14 @@ export function sentryDsn_() {
 }
 
 export function scrollToVetrina() {
+  const header = document.querySelector("header.header-container-container");
   const vetrina = document.querySelector(".vetrina--container");
-  if (vetrina)
-    // Missing from purescript-web-html
-    vetrina.scrollIntoView({ block: "start", inline: "nearest", behavior: "smooth" });
+  if (vetrina) {
+    const headerOffset = header ? header.clientHeight : 0;
+    const vetrinaPosition = vetrina.getBoundingClientRect().top - document.body.getBoundingClientRect().top;
+    window.scrollTo({
+         top: vetrinaPosition - headerOffset,
+         behavior: "smooth"
+    });
+  }
 }

--- a/packages/vetrina/src/Vetrina/Vetrina.purs
+++ b/packages/vetrina/src/Vetrina/Vetrina.purs
@@ -122,7 +122,6 @@ component = do
       case state.purchaseState of
         PurchaseFailed _    -> stop
         PurchaseCompleted _ -> stop
-        NewPurchase         -> stop
         _                   -> pure unit
       pure $ Aff.launchAff_ $ killOrderPoller state
 


### PR DESCRIPTION
- This will stop the page scrolling to Vetrina immediately when article is loaded. Tested with Nets test cards to make sure the autoscrolling still works in cases of failure  and such.

- Also re-wrote the scrolling function so that it takes the fixed header height into account so it doesn't overlap with Vetrina.