### PR TITLE
Fix grey links again

### DIFF
--- a/apps/app-article-server/src/browser/index.css
+++ b/apps/app-article-server/src/browser/index.css
@@ -61,7 +61,7 @@
 
 /* Try to remove grey background sometimes present on hyperlinks */
 a {
-  background-color: transparent;
+  background-color: transparent !important;
 }
 
 body {


### PR DESCRIPTION
For reasons sometimes there are inline background colors on some links. This should remove that.