### PR TITLE
Fix/remove external scripts from most read articles in app-article-server

### DIFF
--- a/apps/app-article-server/src/browser/components/article-content.js
+++ b/apps/app-article-server/src/browser/components/article-content.js
@@ -60,6 +60,7 @@ class Content extends Component {
       <figure className="relatedArticles" key={key}>
         <ul>
           {block.related.map((item, index) => {
+            delete item.externalScripts;
             return (
               <li key={"related-article-" + index}>
                 <a href={"/article/" + item.uuid + this.props.queryString}>

--- a/apps/app-article-server/src/browser/components/article-content.js
+++ b/apps/app-article-server/src/browser/components/article-content.js
@@ -150,7 +150,6 @@ class Content extends Component {
           </div>
           <div className={`col-10 quote ${this.props.darkModeEnabled ? "darkMode" : ""}`} style={{ paddingLeft: "0px" }}>
               {block.quote.body}
-              {/* After the upgrade to Lettera V4, block.quote.author available. */}
           </div>
         </div>
       </div>


### PR DESCRIPTION
These scripts caused some weird JSON to appear at the top of the page if one of the scripts were syntactically invalid. Apparently, rendering executes the scritps. Fixes https://trello.com/c/5bRlQoNX/1558-fix-problems-encountered-in-app-article-server-migration-to-lettera-v4