### PR TITLE
Only send errors originating from our own code to sentry

### DIFF
--- a/packages/components/src/Sentry.js
+++ b/packages/components/src/Sentry.js
@@ -18,7 +18,7 @@ export function initSentry_(sentryDsn, tSampleRate) {
       // Only allow errors from code hosted on our own domains
       allowUrls: 
         [
-          /https?:\/\/([a-z,\-]+\.)?([a-z,\-]+\.)?(hbl|ksfmedia|ostnyland|vastranyland)\.fi/i,
+          /https?:\/\/([a-z\-]+\.)?([a-z\-]+\.)?(hbl|ksfmedia|ostnyland|vastranyland)\.fi/i,
         ],
     });
     return Sentry;

--- a/packages/components/src/Sentry.js
+++ b/packages/components/src/Sentry.js
@@ -15,14 +15,11 @@ export function initSentry_(sentryDsn, tSampleRate) {
       dsn: sentryDsn,
       integrations: [new Tracing.BrowserTracing()],
       tracesSampleRate: tSampleRate,
-      beforeSend(event, hint) {
-        const error = hint.originalException;
-        // Ignore an error caused by Instagram's browser
-        if (error && error.message && error.message.match(/_AutofillCallbackHandler/i)) {
-          return null;
-        }
-        return event;
-      },
+      // Only allow errors from code hosted on our own domains
+      allowUrls: 
+        [
+          /https?:\/\/([a-z,\-]+\.)?([a-z,\-]+\.)?(hbl|ksfmedia|ostnyland|vastranyland)\.fi/i,
+        ],
     });
     return Sentry;
   } else {


### PR DESCRIPTION
Instead of filtering by error message filter out everything not originating from our own domains.