### PR TITLE
Add a filter for "unfixable" errors to Sentry

### DIFF
--- a/packages/components/src/Sentry.js
+++ b/packages/components/src/Sentry.js
@@ -38,7 +38,7 @@ function filterBeforeSend(event, hint) {
   if (
     error &&
     error.message &&
-    error.message.match(/null is not an object (evaluating 'Object.prototype.hasOwnProperty.call(o,"telephone")'))/i)
+    error.message.match(/null is not an object \(evaluating 'Object\.prototype\.hasOwnProperty\.call\(o,"telephone"\)'\)\)/i)
   ) {
     return null;
   }

--- a/packages/components/src/Sentry.js
+++ b/packages/components/src/Sentry.js
@@ -16,12 +16,12 @@ export function initSentry_(sentryDsn, tSampleRate) {
       integrations: [new Tracing.BrowserTracing()],
       tracesSampleRate: tSampleRate,
       // Only allow errors from code hosted on our own domains
-      allowUrls: 
+      allowUrls:
         [
           /https?:\/\/([a-z\-]+\.)?([a-z\-]+\.)?(hbl|ksfmedia|ostnyland|vastranyland)\.fi/i,
         ],
       beforeSend(event, hint) {
-        return filterBeforeSend(event, hint)
+        return filterBeforeSend(event, hint);
       },
     });
     return Sentry;
@@ -36,12 +36,13 @@ function filterBeforeSend(event, hint) {
   const error = hint.originalException;
   // for some reason iOS devices want to access the nonexistent telephone field of our journalists
   if (
-      error && 
-      error.message && 
-      error.message.match(/null is not an object (evaluating 'Object.prototype.hasOwnProperty.call(o,"telephone")'))/i)
-     ) {
-      return null
-     }
+    error &&
+    error.message &&
+    error.message.match(/null is not an object (evaluating 'Object.prototype.hasOwnProperty.call(o,"telephone")'))/i)
+  ) {
+    return null;
+  }
+  return event;
 }
 
 export function captureMessage_(sentry, appName, message, level) {

--- a/packages/components/src/Sentry.js
+++ b/packages/components/src/Sentry.js
@@ -20,12 +20,28 @@ export function initSentry_(sentryDsn, tSampleRate) {
         [
           /https?:\/\/([a-z\-]+\.)?([a-z\-]+\.)?(hbl|ksfmedia|ostnyland|vastranyland)\.fi/i,
         ],
+      beforeSend(event, hint) {
+        return filterBeforeSend(event, hint)
+      },
     });
     return Sentry;
   } else {
     console.warn("Could not setup Sentry, dsn is faulty. Look into your env variables.");
     return null;
   }
+}
+
+// function for filtering out "unfixable" errors
+function filterBeforeSend(event, hint) {
+  const error = hint.originalException;
+  // for some reason iOS devices want to access the nonexistent telephone field of our journalists
+  if (
+      error && 
+      error.message && 
+      error.message.match(/null is not an object (evaluating 'Object.prototype.hasOwnProperty.call(o,"telephone")'))/i)
+     ) {
+      return null
+     }
 }
 
 export function captureMessage_(sentry, appName, message, level) {


### PR DESCRIPTION
This should filter out the masses of sentry errors generated by iOS devices trying to access the nonexistent telephone field of our writers.